### PR TITLE
🧹 ci(workflows): add automatic PR cache cleanup

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,32 @@
+name: 🧹 Cleanup Caches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: 🗑️ Remove PR caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: 🧹 Clean up PR caches
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache keys for $BRANCH"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1)
+
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<div align=center><img src="https://media3.giphy.com/media/v1.Y2lkPWVjMTJjNzA0d3ExMjhtcWdhbjNldDJ0dml5ZHJ6cHI5cDg5aGN5a2l3ZnEwdnowbyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/gEYimIgoXbZr1lyOpZ/giphy.gif" /></div>

---

## Problem

GitHub Actions caches from merged PRs (especially dependabot branches) accumulate over time, consuming storage quota. Each dependabot PR creates new cache entries (~430MB for Playwright alone) that persist indefinitely after merge since they're never accessed again.

## Proposal

Add a cleanup workflow that automatically deletes all caches associated with a PR branch when the PR is closed or merged. This prevents cache buildup from short-lived branches like dependabot updates.