### PR TITLE
📝 docs(ci): add comment explaining gate job purpose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,8 @@ jobs:
           path: e2e/playwright-report/
           retention-days: 30
 
+  # Gate job for branch protection - ensures skipped jobs don't block merging
+  # @see https://www.pantsbuild.org/blog/2022/10/10/skipping-github-actions-jobs-without-breaking-branch-protection
   ci-status:
     name: ✅ CI Status
     needs: [build, e2e-setup, format, lint, test, e2e-tests]


### PR DESCRIPTION
<div align=center><img src="https://media4.giphy.com/media/v1.Y2lkPWVjMTJjNzA0amo2bjQza3Z4czlpcTQwdndxdDlrc2F2YnZqbmhmeDZsbGV5cmRoYyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/vtFZ8O85q8g3MmXK51/giphy.gif" /></div>

---

## Problem

The recently added `ci-status` gate job lacks documentation explaining its purpose. Without context, future maintainers may not understand why this job exists or how it relates to branch protection rules.

## Proposal

Add a concise inline comment explaining that this is a gate job for branch protection that ensures skipped jobs (like the markdown formatter on push events) don't block merging.