### PR TITLE
🚧 feat: add maintenance mode to disable partner space modifications

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,5 +10,5 @@ PCDB_API_URL="http://localhost:8000"
 PCDB_API_SECRET="pcdb-api-secret-key"
 MONGODB_CONNECTION_STRING=mongodb://fc:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true
 DATABASE_URL="postgresql://usr:pwd@localhost:5432/proconnect_ep"
-FEATURE_DISPLAY_MAINTENANCE_MODE=false
-NEXT_PUBLIC_FEATURE_DISPLAY_MAINTENANCE_MODE=false
+IS_YOUR_APPLICATIONS_SERVICE_DISABLED=false
+NEXT_PUBLIC_MAINTENANCE_BANNER_MESSAGE=""

--- a/.env.development
+++ b/.env.development
@@ -10,3 +10,5 @@ PCDB_API_URL="http://localhost:8000"
 PCDB_API_SECRET="pcdb-api-secret-key"
 MONGODB_CONNECTION_STRING=mongodb://fc:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true
 DATABASE_URL="postgresql://usr:pwd@localhost:5432/proconnect_ep"
+FEATURE_DISPLAY_MAINTENANCE_MODE=false
+NEXT_PUBLIC_FEATURE_DISPLAY_MAINTENANCE_MODE=false

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -4,8 +4,14 @@ export const MaintenanceBanner = () => {
   return (
     <div className={fr.cx("fr-container", "fr-my-10w")}>
       <div className={fr.cx("fr-alert", "fr-alert--info")}>
-        <h3 className={fr.cx("fr-alert__title")}>Espace partenaire en maintenance</h3>
-        <p>L’espace partenaire est temporairement indisponible en raison d’une opération de maintenance. Les modifications sont momentanément désactivées.</p>
+        <h3 className={fr.cx("fr-alert__title")}>
+          Espace partenaire en maintenance
+        </h3>
+        <p>
+          L’espace partenaire est temporairement indisponible en raison d’une
+          opération de maintenance. Les modifications sont momentanément
+          désactivées.
+        </p>
       </div>
     </div>
   );

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -4,13 +4,10 @@ export const MaintenanceBanner = () => {
   return (
     <div className={fr.cx("fr-container", "fr-my-10w")}>
       <div className={fr.cx("fr-alert", "fr-alert--info")}>
-        <h3 className={fr.cx("fr-alert__title")}>
-          Espace partenaire en maintenance
-        </h3>
+        <h3 className={fr.cx("fr-alert__title")}>Espace partenaire en maintenance</h3>
         <p>
-          L’espace partenaire est temporairement indisponible en raison d’une
-          opération de maintenance. Les modifications sont momentanément
-          désactivées.
+          L’espace partenaire est temporairement indisponible en raison d’une opération de
+          maintenance. Les modifications sont momentanément désactivées.
         </p>
       </div>
     </div>

--- a/src/components/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,12 @@
+import { fr } from "@codegouvfr/react-dsfr";
+
+export const MaintenanceBanner = () => {
+  return (
+    <div className={fr.cx("fr-container", "fr-my-10w")}>
+      <div className={fr.cx("fr-alert", "fr-alert--info")}>
+        <h3 className={fr.cx("fr-alert__title")}>Espace partenaire en maintenance</h3>
+        <p>L’espace partenaire est temporairement indisponible en raison d’une opération de maintenance. Les modifications sont momentanément désactivées.</p>
+      </div>
+    </div>
+  );
+};

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -7,6 +7,7 @@ import { Header } from "@codegouvfr/react-dsfr/Header";
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import Notice from "@codegouvfr/react-dsfr/Notice";
 
 const brandTop = (
   <>
@@ -124,6 +125,13 @@ export function PageLayout({ children }: LayoutProps) {
           },
         ]}
       />
+      {process.env.NEXT_PUBLIC_FEATURE_DISPLAY_MAINTENANCE_MODE === "true" && (
+        <Notice
+          title=""
+          description="Le service « Vos applications », de l'espace partenaire, est temporairement indisponible en raison d'une opération de maintenance."
+          isClosable
+        />
+      )}
       <Header
         brandTop={brandTop}
         serviceTitle="Espace Partenaires ProConnect"

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -125,10 +125,10 @@ export function PageLayout({ children }: LayoutProps) {
           },
         ]}
       />
-      {process.env.NEXT_PUBLIC_FEATURE_DISPLAY_MAINTENANCE_MODE === "true" && (
+      {!!process.env.NEXT_PUBLIC_MAINTENANCE_BANNER_MESSAGE && (
         <Notice
           title=""
-          description="Le service « Vos applications », de l'espace partenaire, est temporairement indisponible en raison d'une opération de maintenance."
+          description={process.env.NEXT_PUBLIC_MAINTENANCE_BANNER_MESSAGE}
           isClosable
         />
       )}

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -61,9 +61,7 @@ export function PageLayout({ children }: LayoutProps) {
     {
       text: "Contribuer sur GitHub",
       linkProps: {
-        href:
-          `${process.env.NEXT_PUBLIC_APP_REPOSITORY_URL}` +
-          getGithubDeepLink(router.asPath),
+        href: `${process.env.NEXT_PUBLIC_APP_REPOSITORY_URL}` + getGithubDeepLink(router.asPath),
       },
     },
   ];
@@ -107,10 +105,7 @@ export function PageLayout({ children }: LayoutProps) {
     <>
       <Head>
         {contentSecurityPolicy && (
-          <meta
-            httpEquiv="Content-Security-Policy"
-            content={contentSecurityPolicy}
-          />
+          <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
         )}
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -4,10 +4,10 @@ import { signOut, useSession } from "next-auth/react";
 
 import { Footer } from "@codegouvfr/react-dsfr/Footer";
 import { Header } from "@codegouvfr/react-dsfr/Header";
+import Notice from "@codegouvfr/react-dsfr/Notice";
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import Notice from "@codegouvfr/react-dsfr/Notice";
 
 const brandTop = (
   <>
@@ -61,7 +61,9 @@ export function PageLayout({ children }: LayoutProps) {
     {
       text: "Contribuer sur GitHub",
       linkProps: {
-        href: `${process.env.NEXT_PUBLIC_APP_REPOSITORY_URL}` + getGithubDeepLink(router.asPath),
+        href:
+          `${process.env.NEXT_PUBLIC_APP_REPOSITORY_URL}` +
+          getGithubDeepLink(router.asPath),
       },
     },
   ];
@@ -105,7 +107,10 @@ export function PageLayout({ children }: LayoutProps) {
     <>
       <Head>
         {contentSecurityPolicy && (
-          <meta httpEquiv="Content-Security-Policy" content={contentSecurityPolicy} />
+          <meta
+            httpEquiv="Content-Security-Policy"
+            content={contentSecurityPolicy}
+          />
         )}
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -24,8 +24,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const { id } = context.params as { id: string };
 
-  const isMaintenanceMode =
-    process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
 
   try {
     const app = await pcdbClient.getOidcClient(id, session.user.email);
@@ -60,9 +59,7 @@ export default function AppDetailPage({
   const [data, setData] = useState(app);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [idTokenSignatureAlg, setIdTokenSignatureAlg] = useState(
-    data.id_token_signed_response_alg,
-  );
+  const [idTokenSignatureAlg, setIdTokenSignatureAlg] = useState(data.id_token_signed_response_alg);
   const [userInfoSignatureAlg, setUserInfoSignatureAlg] = useState(
     data.userinfo_signed_response_alg || "",
   );
@@ -122,9 +119,7 @@ export default function AppDetailPage({
     }
   };
 
-  const handleIdTokenSignatureAlgChange = async (
-    e: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
+  const handleIdTokenSignatureAlgChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newAlg = e.target.value;
     setIdTokenSignatureAlg(newAlg);
 
@@ -138,9 +133,7 @@ export default function AppDetailPage({
     }
   };
 
-  const handleUserInfoSignatureAlgChange = async (
-    e: React.ChangeEvent<HTMLSelectElement>,
-  ) => {
+  const handleUserInfoSignatureAlgChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newAlg = e.target.value;
     setUserInfoSignatureAlg(newAlg);
 
@@ -167,9 +160,7 @@ export default function AppDetailPage({
           <div className={fr.cx("fr-col-12", "fr-col-md-9", "fr-py-12v")}>
             <Breadcrumb
               currentPageLabel={data.name}
-              segments={[
-                { label: "Applications", linkProps: { href: "/apps" } },
-              ]}
+              segments={[{ label: "Applications", linkProps: { href: "/apps" } }]}
             />
 
             <div className={fr.cx("fr-mb-4w")}>
@@ -213,10 +204,7 @@ export default function AppDetailPage({
                   <CopyableField label="Client ID" value={data.key || ""} />
                 </div>
                 <div className={fr.cx("fr-col-12", "fr-mt-2w")}>
-                  <CopyableField
-                    label="Client Secret"
-                    value={data.client_secret || ""}
-                  />
+                  <CopyableField label="Client Secret" value={data.client_secret || ""} />
                 </div>
               </div>
             </div>
@@ -247,8 +235,7 @@ export default function AppDetailPage({
               <h1 id="algs">Algorithmes</h1>
               <h2>Algorithme de signature ID Token</h2>
               <p>
-                L&rsquo;algorithme de signature est utilisé pour signer les
-                jetons d&rsquo;identité.
+                L&rsquo;algorithme de signature est utilisé pour signer les jetons d&rsquo;identité.
               </p>
               <Select
                 label="Algorithme de signature"
@@ -268,8 +255,8 @@ export default function AppDetailPage({
             <div id="alg-user-info" className={fr.cx("fr-mb-10v")}>
               <h2>Algorithme de signature user-info</h2>
               <p>
-                L&rsquo;algorithme de signature est utilisé pour signer les
-                informations utilisateur.
+                L&rsquo;algorithme de signature est utilisé pour signer les informations
+                utilisateur.
               </p>
               <Select
                 label="Algorithme de signature user-info"
@@ -294,12 +281,8 @@ export default function AppDetailPage({
               <h2>Passage en production</h2>
               <p>Cette application est encore en test.</p>
               <p>
-                Pour connaître les étapes à suivre pour passer en production,
-                veuillez{" "}
-                <Link
-                  href="/docs/fournisseur-service"
-                  className={fr.cx("fr-link")}
-                >
+                Pour connaître les étapes à suivre pour passer en production, veuillez{" "}
+                <Link href="/docs/fournisseur-service" className={fr.cx("fr-link")}>
                   consulter la documentation
                 </Link>
                 .

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -14,6 +14,8 @@ import { NotificationsContainer } from "../../components/NotificationsContainer"
 import { ProviderUrl } from "../../components/ProviderUrl";
 import { OidcClient, pcdbClient } from "../../lib/pcdbapi";
 import { authOptions } from "../api/auth/[...nextauth]";
+import { MaintenanceBanner } from "../../components/MaintenanceBanner";
+
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -22,9 +24,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
 
   const { id } = context.params as { id: string };
+
+  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+
   try {
     const app = await pcdbClient.getOidcClient(id, session.user.email);
-    return { props: { app } };
+    return { props: { app, isMaintenanceMode } };
   } catch {
     return { notFound: true };
   }
@@ -45,7 +50,7 @@ const SIGNATURE_ALGORITHMS = [
   },
 ] as const;
 
-export default function AppDetailPage({ app }: { app: OidcClient }) {
+export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcClient; isMaintenanceMode: boolean }) {
   const [data, setData] = useState(app);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
@@ -136,6 +141,10 @@ export default function AppDetailPage({ app }: { app: OidcClient }) {
       setSaveError("Failed to update user-info signature algorithm");
     }
   };
+
+  if (isMaintenanceMode) {
+     return <MaintenanceBanner />;
+  }
 
   return (
     <>

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -10,12 +10,11 @@ import Link from "next/link";
 import { useCallback, useMemo, useState } from "react";
 import { SideMenu } from "../../components/AppSideMenu";
 import { CopyableField } from "../../components/CopyableField";
+import { MaintenanceBanner } from "../../components/MaintenanceBanner";
 import { NotificationsContainer } from "../../components/NotificationsContainer";
 import { ProviderUrl } from "../../components/ProviderUrl";
 import { OidcClient, pcdbClient } from "../../lib/pcdbapi";
 import { authOptions } from "../api/auth/[...nextauth]";
-import { MaintenanceBanner } from "../../components/MaintenanceBanner";
-
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -25,7 +24,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const { id } = context.params as { id: string };
 
-  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isMaintenanceMode =
+    process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
 
   try {
     const app = await pcdbClient.getOidcClient(id, session.user.email);
@@ -50,11 +50,19 @@ const SIGNATURE_ALGORITHMS = [
   },
 ] as const;
 
-export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcClient; isMaintenanceMode: boolean }) {
+export default function AppDetailPage({
+  app,
+  isMaintenanceMode,
+}: {
+  app: OidcClient;
+  isMaintenanceMode: boolean;
+}) {
   const [data, setData] = useState(app);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
-  const [idTokenSignatureAlg, setIdTokenSignatureAlg] = useState(data.id_token_signed_response_alg);
+  const [idTokenSignatureAlg, setIdTokenSignatureAlg] = useState(
+    data.id_token_signed_response_alg,
+  );
   const [userInfoSignatureAlg, setUserInfoSignatureAlg] = useState(
     data.userinfo_signed_response_alg || "",
   );
@@ -114,7 +122,9 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
     }
   };
 
-  const handleIdTokenSignatureAlgChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleIdTokenSignatureAlgChange = async (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
     const newAlg = e.target.value;
     setIdTokenSignatureAlg(newAlg);
 
@@ -128,7 +138,9 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
     }
   };
 
-  const handleUserInfoSignatureAlgChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleUserInfoSignatureAlgChange = async (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
     const newAlg = e.target.value;
     setUserInfoSignatureAlg(newAlg);
 
@@ -143,7 +155,7 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
   };
 
   if (isMaintenanceMode) {
-     return <MaintenanceBanner />;
+    return <MaintenanceBanner />;
   }
 
   return (
@@ -155,7 +167,9 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
           <div className={fr.cx("fr-col-12", "fr-col-md-9", "fr-py-12v")}>
             <Breadcrumb
               currentPageLabel={data.name}
-              segments={[{ label: "Applications", linkProps: { href: "/apps" } }]}
+              segments={[
+                { label: "Applications", linkProps: { href: "/apps" } },
+              ]}
             />
 
             <div className={fr.cx("fr-mb-4w")}>
@@ -199,7 +213,10 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
                   <CopyableField label="Client ID" value={data.key || ""} />
                 </div>
                 <div className={fr.cx("fr-col-12", "fr-mt-2w")}>
-                  <CopyableField label="Client Secret" value={data.client_secret || ""} />
+                  <CopyableField
+                    label="Client Secret"
+                    value={data.client_secret || ""}
+                  />
                 </div>
               </div>
             </div>
@@ -230,7 +247,8 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
               <h1 id="algs">Algorithmes</h1>
               <h2>Algorithme de signature ID Token</h2>
               <p>
-                L&rsquo;algorithme de signature est utilisé pour signer les jetons d&rsquo;identité.
+                L&rsquo;algorithme de signature est utilisé pour signer les
+                jetons d&rsquo;identité.
               </p>
               <Select
                 label="Algorithme de signature"
@@ -250,8 +268,8 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
             <div id="alg-user-info" className={fr.cx("fr-mb-10v")}>
               <h2>Algorithme de signature user-info</h2>
               <p>
-                L&rsquo;algorithme de signature est utilisé pour signer les informations
-                utilisateur.
+                L&rsquo;algorithme de signature est utilisé pour signer les
+                informations utilisateur.
               </p>
               <Select
                 label="Algorithme de signature user-info"
@@ -276,8 +294,12 @@ export default function AppDetailPage({ app, isMaintenanceMode }: { app: OidcCli
               <h2>Passage en production</h2>
               <p>Cette application est encore en test.</p>
               <p>
-                Pour connaître les étapes à suivre pour passer en production, veuillez{" "}
-                <Link href="/docs/fournisseur-service" className={fr.cx("fr-link")}>
+                Pour connaître les étapes à suivre pour passer en production,
+                veuillez{" "}
+                <Link
+                  href="/docs/fournisseur-service"
+                  className={fr.cx("fr-link")}
+                >
                   consulter la documentation
                 </Link>
                 .

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -24,11 +24,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const { id } = context.params as { id: string };
 
-  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isYourApplicationsServiceDisabled =
+    process.env.IS_YOUR_APPLICATIONS_SERVICE_DISABLED === "true";
 
   try {
     const app = await pcdbClient.getOidcClient(id, session.user.email);
-    return { props: { app, isMaintenanceMode } };
+    return { props: { app, isYourApplicationsServiceDisabled } };
   } catch {
     return { notFound: true };
   }
@@ -51,10 +52,10 @@ const SIGNATURE_ALGORITHMS = [
 
 export default function AppDetailPage({
   app,
-  isMaintenanceMode,
+  isYourApplicationsServiceDisabled,
 }: {
   app: OidcClient;
-  isMaintenanceMode: boolean;
+  isYourApplicationsServiceDisabled: boolean;
 }) {
   const [data, setData] = useState(app);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -147,7 +148,7 @@ export default function AppDetailPage({
     }
   };
 
-  if (isMaintenanceMode) {
+  if (isYourApplicationsServiceDisabled) {
     return <MaintenanceBanner />;
   }
 

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -5,10 +5,9 @@ import { Card } from "@codegouvfr/react-dsfr/Card";
 import { GetServerSideProps } from "next";
 import { getServerSession } from "next-auth/next";
 import { useState } from "react";
+import { MaintenanceBanner } from "../../components/MaintenanceBanner";
 import { OidcClient, pcdbClient } from "../../lib/pcdbapi";
 import { authOptions } from "../api/auth/[...nextauth]";
-import { MaintenanceBanner } from "../../components/MaintenanceBanner";
-
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -22,7 +21,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isMaintenanceMode =
+    process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
 
   try {
     const apps = await pcdbClient.listOidcClients(session.user.email);
@@ -32,16 +32,31 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
 };
 
-export default function AppsIndex({ apps, error, isMaintenanceMode }: { apps: OidcClient[]; error?: string; isMaintenanceMode: boolean }) {
+export default function AppsIndex({
+  apps,
+  error,
+  isMaintenanceMode,
+}: {
+  apps: OidcClient[];
+  error?: string;
+  isMaintenanceMode: boolean;
+}) {
   const [isCreating, setIsCreating] = useState(false);
-  
- if (isMaintenanceMode) {
-  return <MaintenanceBanner />;
-}
+
+  if (isMaintenanceMode) {
+    return <MaintenanceBanner />;
+  }
 
   if (error) {
     return (
-      <div className={fr.cx("fr-alert", "fr-alert--error", "fr-mb-3w", "fr-container")}>
+      <div
+        className={fr.cx(
+          "fr-alert",
+          "fr-alert--error",
+          "fr-mb-3w",
+          "fr-container",
+        )}
+      >
         <p>{error}</p>
       </div>
     );
@@ -79,28 +94,47 @@ export default function AppsIndex({ apps, error, isMaintenanceMode }: { apps: Oi
       >
         <div className={fr.cx("fr-container")}>
           <h1>Vos applications</h1>
-          <p>Gérez vos applications OpenID Connect en cours de développement.</p>
+          <p>
+            Gérez vos applications OpenID Connect en cours de développement.
+          </p>
         </div>
       </section>
 
       <div className={fr.cx("fr-my-4w", "fr-container")}>
-        <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
+        <div
+          className={fr.cx(
+            "fr-grid-row",
+            "fr-grid-row--middle",
+            "fr-grid-row--gutters",
+          )}
+        >
           <div className={fr.cx("fr-col")}>
             <h2>Fournisseurs de Service</h2>
           </div>
         </div>
 
-        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-pb-6w")}>
+        <div
+          className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-pb-6w")}
+        >
           {apps.length === 0 && (
             <div className={fr.cx("fr-col-12")}>
-              <p>Aucun Fournisseur de Service n&rsquo;est encore associé à votre email.</p>
+              <p>
+                Aucun Fournisseur de Service n&rsquo;est encore associé à votre
+                email.
+              </p>
               <p>Vous pouvez en créer un avec le bouton ci-dessous.</p>
             </div>
           )}
 
           <div className={fr.cx("fr-col-12")}>
-            <Button onClick={handleCreate} disabled={isCreating} iconId="fr-icon-add-line">
-              {isCreating ? "Création en cours..." : "Créer un nouveau fournisseur de service"}
+            <Button
+              onClick={handleCreate}
+              disabled={isCreating}
+              iconId="fr-icon-add-line"
+            >
+              {isCreating
+                ? "Création en cours..."
+                : "Créer un nouveau fournisseur de service"}
             </Button>
           </div>
 
@@ -133,11 +167,15 @@ export default function AppsIndex({ apps, error, isMaintenanceMode }: { apps: Oi
                   <span className={fr.cx("fr-mb-0", "fr-text--xs")}>
                     {app.createdAt && app.updatedAt && (
                       <span className={fr.cx("fr-mb-0", "fr-text--md")}>
-                        <strong>Date de création :</strong> {app.createdAt.substring(8, 10)}/
-                        {app.createdAt.substring(5, 7)}/{app.createdAt.substring(0, 4)}
+                        <strong>Date de création :</strong>{" "}
+                        {app.createdAt.substring(8, 10)}/
+                        {app.createdAt.substring(5, 7)}/
+                        {app.createdAt.substring(0, 4)}
                         <br />
-                        <strong>Date de mise à jour :</strong> {app.updatedAt.substring(8, 10)}/
-                        {app.updatedAt.substring(5, 7)}/{app.updatedAt.substring(0, 4)}
+                        <strong>Date de mise à jour :</strong>{" "}
+                        {app.updatedAt.substring(8, 10)}/
+                        {app.updatedAt.substring(5, 7)}/
+                        {app.updatedAt.substring(0, 4)}
                       </span>
                     )}
                   </span>

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -21,11 +21,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isYourApplicationsServiceDisabled =
+    process.env.IS_YOUR_APPLICATIONS_SERVICE_DISABLED === "true";
 
   try {
     const apps = await pcdbClient.listOidcClients(session.user.email);
-    return { props: { apps, isMaintenanceMode } };
+    return { props: { apps, isYourApplicationsServiceDisabled } };
   } catch (error) {
     return { props: { apps: [], error: String(error) } };
   }
@@ -34,15 +35,15 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 export default function AppsIndex({
   apps,
   error,
-  isMaintenanceMode,
+  isYourApplicationsServiceDisabled,
 }: {
   apps: OidcClient[];
   error?: string;
-  isMaintenanceMode: boolean;
+  isYourApplicationsServiceDisabled: boolean;
 }) {
   const [isCreating, setIsCreating] = useState(false);
 
-  if (isMaintenanceMode) {
+  if (isYourApplicationsServiceDisabled) {
     return <MaintenanceBanner />;
   }
 

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -7,6 +7,8 @@ import { getServerSession } from "next-auth/next";
 import { useState } from "react";
 import { OidcClient, pcdbClient } from "../../lib/pcdbapi";
 import { authOptions } from "../api/auth/[...nextauth]";
+import { MaintenanceBanner } from "../../components/MaintenanceBanner";
+
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const session = await getServerSession(context.req, context.res, authOptions);
@@ -20,16 +22,22 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
+  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+
   try {
     const apps = await pcdbClient.listOidcClients(session.user.email);
-    return { props: { apps } };
+    return { props: { apps, isMaintenanceMode } };
   } catch (error) {
     return { props: { apps: [], error: String(error) } };
   }
 };
 
-export default function AppsIndex({ apps, error }: { apps: OidcClient[]; error?: string }) {
+export default function AppsIndex({ apps, error, isMaintenanceMode }: { apps: OidcClient[]; error?: string; isMaintenanceMode: boolean }) {
   const [isCreating, setIsCreating] = useState(false);
+  
+ if (isMaintenanceMode) {
+  return <MaintenanceBanner />;
+}
 
   if (error) {
     return (

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -21,8 +21,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     };
   }
 
-  const isMaintenanceMode =
-    process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
+  const isMaintenanceMode = process.env.FEATURE_DISPLAY_MAINTENANCE_MODE === "true";
 
   try {
     const apps = await pcdbClient.listOidcClients(session.user.email);
@@ -49,14 +48,7 @@ export default function AppsIndex({
 
   if (error) {
     return (
-      <div
-        className={fr.cx(
-          "fr-alert",
-          "fr-alert--error",
-          "fr-mb-3w",
-          "fr-container",
-        )}
-      >
+      <div className={fr.cx("fr-alert", "fr-alert--error", "fr-mb-3w", "fr-container")}>
         <p>{error}</p>
       </div>
     );
@@ -94,47 +86,28 @@ export default function AppsIndex({
       >
         <div className={fr.cx("fr-container")}>
           <h1>Vos applications</h1>
-          <p>
-            Gérez vos applications OpenID Connect en cours de développement.
-          </p>
+          <p>Gérez vos applications OpenID Connect en cours de développement.</p>
         </div>
       </section>
 
       <div className={fr.cx("fr-my-4w", "fr-container")}>
-        <div
-          className={fr.cx(
-            "fr-grid-row",
-            "fr-grid-row--middle",
-            "fr-grid-row--gutters",
-          )}
-        >
+        <div className={fr.cx("fr-grid-row", "fr-grid-row--middle", "fr-grid-row--gutters")}>
           <div className={fr.cx("fr-col")}>
             <h2>Fournisseurs de Service</h2>
           </div>
         </div>
 
-        <div
-          className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-pb-6w")}
-        >
+        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters", "fr-pb-6w")}>
           {apps.length === 0 && (
             <div className={fr.cx("fr-col-12")}>
-              <p>
-                Aucun Fournisseur de Service n&rsquo;est encore associé à votre
-                email.
-              </p>
+              <p>Aucun Fournisseur de Service n&rsquo;est encore associé à votre email.</p>
               <p>Vous pouvez en créer un avec le bouton ci-dessous.</p>
             </div>
           )}
 
           <div className={fr.cx("fr-col-12")}>
-            <Button
-              onClick={handleCreate}
-              disabled={isCreating}
-              iconId="fr-icon-add-line"
-            >
-              {isCreating
-                ? "Création en cours..."
-                : "Créer un nouveau fournisseur de service"}
+            <Button onClick={handleCreate} disabled={isCreating} iconId="fr-icon-add-line">
+              {isCreating ? "Création en cours..." : "Créer un nouveau fournisseur de service"}
             </Button>
           </div>
 
@@ -167,15 +140,11 @@ export default function AppsIndex({
                   <span className={fr.cx("fr-mb-0", "fr-text--xs")}>
                     {app.createdAt && app.updatedAt && (
                       <span className={fr.cx("fr-mb-0", "fr-text--md")}>
-                        <strong>Date de création :</strong>{" "}
-                        {app.createdAt.substring(8, 10)}/
-                        {app.createdAt.substring(5, 7)}/
-                        {app.createdAt.substring(0, 4)}
+                        <strong>Date de création :</strong> {app.createdAt.substring(8, 10)}/
+                        {app.createdAt.substring(5, 7)}/{app.createdAt.substring(0, 4)}
                         <br />
-                        <strong>Date de mise à jour :</strong>{" "}
-                        {app.updatedAt.substring(8, 10)}/
-                        {app.updatedAt.substring(5, 7)}/
-                        {app.updatedAt.substring(0, 4)}
+                        <strong>Date de mise à jour :</strong> {app.updatedAt.substring(8, 10)}/
+                        {app.updatedAt.substring(5, 7)}/{app.updatedAt.substring(0, 4)}
                       </span>
                     )}
                   </span>


### PR DESCRIPTION
I display the same error message on the /app and /app/[id] paths, so that users who know their service provider’s path by heart cannot access the page for editing their details.

<img width="1440" height="833" alt="Capture d’écran 2026-04-14 à 17 05 02" src="https://github.com/user-attachments/assets/f38b36f3-bfca-43a9-9185-9173cef0aa64" />

<img width="1439" height="834" alt="Capture d’écran 2026-04-14 à 17 05 26" src="https://github.com/user-attachments/assets/1e208cc7-1ca3-4597-867e-4c28811f2991" />
