### PR TITLE
docs(fi): clarify that user claims are returned via /user-info

### DIFF
--- a/src/pages/docs/fournisseur-identite/configuration.md
+++ b/src/pages/docs/fournisseur-identite/configuration.md
@@ -80,6 +80,8 @@ Les spécifications des algorithmes de signatures utilisés sont les suivants :
 
 ### 3.1. Scopes
 
+ProConnect récupère les claims utilisateur en appelant l'endpoint `/user-info` de votre FI. L'ID token retourné par `/token` doit contenir les claims `sub`, `acr` et `amr` ; les autres claims listés ci-dessous doivent être exposés via `/user-info`. Pour les contraintes appliquées sur ces valeurs, consultez [la page dédiée au format de l'userinfo](./format-user-info.md).
+
 La liste des scopes demandés par ProConnect est la suivante :
 | Scopes |
 | --- |

--- a/src/pages/docs/fournisseur-identite/format-user-info.md
+++ b/src/pages/docs/fournisseur-identite/format-user-info.md
@@ -1,5 +1,7 @@
 # Contrôle des identités retournés par les userinfos des FI
 
+Après avoir récupéré l'ID token via `/token`, ProConnect appelle l'endpoint `/user-info` de votre FI pour obtenir les claims utilisateur (scopes listés dans la [section 3.1 de la configuration](./configuration.md#31-scopes)). C'est donc bien `/user-info` qui doit exposer ces données, et non l'ID token.
+
 Pour que ProConnect reconnaisse comme valide une identité, le FI doit retourner les champs obligatoires définis [ici](./configuration.md#31-scopes) en respectant les contraintes.
 
 ## Siret


### PR DESCRIPTION
## Summary

- Adds a paragraph in `configuration.md` section 3.1 to explicitly state that the listed scopes/claims must be exposed via `/user-info`, and that the ID token (from `/token`) should contain `sub`, `acr`, and `amr`
- Adds an intro in `format-user-info.md` explaining the role of `/user-info` in the OIDC flow

## Motivation

One FI integrator was unsure whether to return user claims in the ID token or via `/user-info`. The documentation was silent on this point, leading to a question.

## Review plan

- [ ] Check if correct
- [ ] Check if information is easily accessible