### PR TITLE
Revert ":arrow_upper_right: [patch](deps-dev): Bump nodemailer from 7.0.11 to 8.0.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "next": "15.5.18",
         "next-auth": "^4.24.13",
         "next-seo": "^6.8.0",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^7.0.11",
         "prettier": "^3.6.2",
         "prettier-plugin-gherkin": "^3.1.2",
         "prettier-plugin-organize-imports": "^4.3.0",
@@ -13571,9 +13571,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-gnXhNRE0FNhD7wPSCGhdNh46Hs6nm+uTyg+Kq0cZukNQiYdnCsoQjodNP9BQVG9XrcK/v6/MgpAPBUFyzh9pvw==",
       "dev": true,
       "license": "MIT-0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "next": "15.5.18",
     "next-auth": "^4.24.13",
     "next-seo": "^6.8.0",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^7.0.11",
     "prettier": "^3.6.2",
     "prettier-plugin-gherkin": "^3.1.2",
     "prettier-plugin-organize-imports": "^4.3.0",


### PR DESCRIPTION
Reverts proconnect-gouv/proconnect-espace-partenaires#305


```
$ npm i                                       
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: next-auth@4.24.13
npm error Found: nodemailer@8.0.5
npm error node_modules/nodemailer
npm error   dev nodemailer@"^8.0.5" from the root project
npm error
npm error Could not resolve dependency:
npm error peerOptional nodemailer@"^7.0.7" from next-auth@4.24.13
npm error node_modules/next-auth
npm error   dev next-auth@"^4.24.13" from the root project
npm error   peer next-auth@"^4" from @next-auth/prisma-adapter@1.0.7
npm error   node_modules/@next-auth/prisma-adapter
npm error     dev @next-auth/prisma-adapter@"^1.0.7" from the root project
npm error
npm error Conflicting peer dependency: nodemailer@7.0.13
npm error node_modules/nodemailer
npm error   peerOptional nodemailer@"^7.0.7" from next-auth@4.24.13
npm error   node_modules/next-auth
npm error     dev next-auth@"^4.24.13" from the root project
npm error     peer next-auth@"^4" from @next-auth/prisma-adapter@1.0.7
npm error     node_modules/@next-auth/prisma-adapter
npm error       dev @next-auth/prisma-adapter@"^1.0.7" from the root project
```