### PR TITLE
🚥 e2e: fix uuv webserver setup and flaky loading assertion

### DIFF
--- a/e2e/uuv/features/new_service_provider.feature
+++ b/e2e/uuv/features/new_service_provider.feature
@@ -21,8 +21,6 @@ Fonctionnalité: Créer un nouveau fournisseur de service
 
   Scénario: Créer un nouveau fournisseur de service
     Quand je clique sur le bouton nommé "Créer un nouveau fournisseur de service"
-    Alors je vois "Création en cours..."
-
     Alors je dois voir un titre nommé "Gestion de votre Fournisseur de Service" avec le niveau 1
     Et je clique sur "Nom de l’application"
     Et je vide le champ focalisé

--- a/e2e/uuv/playwright.config.ts
+++ b/e2e/uuv/playwright.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
       cwd: "../..",
       env: {
         MONGODB_CONNECTION_STRING:
-          "mongodb://fc:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true",
+          "mongodb://fc_admin:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true&tls=true&tlsAllowInvalidCertificates=true",
       },
     },
   ],


### PR DESCRIPTION
**Problem**

The MongoDB connection string used for `prisma db push` in the playwright webServer lacked TLS params and used an API-only user without `listCollections` privileges, silently breaking schema setup. The "Création en cours..." assertion was also racing with the API call on fast machines.

**Proposal**

Switch to `fc_admin` with `tls=true&tlsAllowInvalidCertificates=true` so the connection matches MongoDB's `--tlsMode requireTLS` config. Remove the loading-state assertion, which tests implementation detail rather than feature behaviour.