### PR TITLE
🗃️ mongo: rename database to corev2, user to proconnect-app-api-partner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,7 @@ jobs:
           DATABASE_URL: postgresql://usr:pwd@localhost:5432/proconnect_ep
       - run: npx --no prisma db push --schema=./prisma/db_proconnect.prisma
         env:
-          MONGODB_CONNECTION_STRING: mongodb://fc_admin:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true&tls=true&tlsAllowInvalidCertificates=true
+          MONGODB_CONNECTION_STRING: mongodb://fc_admin:pass@localhost:27017/corev2?authSource=admin&replicaSet=rs0&directConnection=true&tls=true&tlsAllowInvalidCertificates=true
 
       - name: 🎬 Run Playwright tests
         working-directory: ./e2e

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=fc_admin
       - MONGO_INITDB_ROOT_PASSWORD=pass
-      - MONGO_INITDB_API_USERNAME=fc
+      - MONGO_INITDB_API_USERNAME=proconnect-app-api-partner
       - MONGO_INITDB_API_PASSWORD=pass
     healthcheck:
       interval: 1s
@@ -43,8 +43,8 @@ services:
   pcdbapi:
     image: ghcr.io/proconnect-gouv/federation/api-partner@sha256:fa9b8bf87daa4bc775c81d2a1dd7dbcc4c42c3f4dd79866b62044f0c9056c7b8 # latest
     environment:
-      - MONGODB_URL=mongodb://mongo:27017/core-fca-low?authSource=core-fca-low&directConnection=true
-      - MONGODB_USERNAME=fc
+      - MONGODB_URL=mongodb://mongo:27017/corev2?authSource=corev2&directConnection=true
+      - MONGODB_USERNAME=proconnect-app-api-partner
       - MONGODB_PASSWORD=pass
       - MONGODB_CERTIFICATE_FILEPATH=/etc/ssl/mongo.pem
       - MONGODB_CA_FILEPATH=/etc/ssl/docker-stack-ca.crt

--- a/docker/mongodb/entrypoint.sh
+++ b/docker/mongodb/entrypoint.sh
@@ -31,7 +31,7 @@ db.createUser({
   roles: [{ role: "root", db: "admin" }]
 });
 
-db = db.getSiblingDB("core-fca-low")
+db = db.getSiblingDB("corev2")
 db.createCollection('client')
 db_test = db.getSiblingDB("proconnect_test")
 db_test.createCollection('client')
@@ -42,14 +42,14 @@ echo "Creating the runtime user"
 mongo ${MONGO_SSL_OPTIONS} --username=${MONGO_INITDB_ROOT_USERNAME} --password=${MONGO_INITDB_ROOT_PASSWORD} <<EOF
 use admin
 
-db = db.getSiblingDB("core-fca-low")
+db = db.getSiblingDB("corev2")
 
 db.createRole({
   role: "role_user_api_partenaires",
   roles: [],
   privileges: [
     {
-      resource: { db: "core-fca-low", collection: "client" },
+      resource: { db: "corev2", collection: "client" },
       actions: [ "find", "update", "insert" ]
     }
   ]
@@ -59,13 +59,13 @@ db.createUser({
   user: "${MONGO_INITDB_API_USERNAME}",
   pwd: "${MONGO_INITDB_API_PASSWORD}",
   roles: [
-    { role: "role_user_api_partenaires", db: "core-fca-low"}
+    { role: "role_user_api_partenaires", db: "corev2"}
   ]
 });
 EOF
 
 echo "Seeding the database..."
-mongoimport ${MONGOIMPORT_SSL_OPTIONS} --username=${MONGO_INITDB_ROOT_USERNAME} --password=${MONGO_INITDB_ROOT_PASSWORD} --authenticationDatabase=admin --db core-fca-low --collection client --file /init/mockdata.json --jsonArray
+mongoimport ${MONGOIMPORT_SSL_OPTIONS} --username=${MONGO_INITDB_ROOT_USERNAME} --password=${MONGO_INITDB_ROOT_PASSWORD} --authenticationDatabase=admin --db corev2 --collection client --file /init/mockdata.json --jsonArray
 
 # Keep the container running
 wait

--- a/e2e/uuv/playwright.config.ts
+++ b/e2e/uuv/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
           "--tls",
           "--tlsAllowInvalidCertificates",
           "--username fc_admin",
-          "core-fca-low",
+          "corev2",
           `--eval "db.dropDatabase()"`,
         ].join(" "),
         "npx prisma db push --schema=./prisma/db_proconnect.prisma",
@@ -83,7 +83,7 @@ export default defineConfig({
       cwd: "../..",
       env: {
         MONGODB_CONNECTION_STRING:
-          "mongodb://fc_admin:pass@localhost:27017/core-fca-low?authSource=admin&replicaSet=rs0&directConnection=true&tls=true&tlsAllowInvalidCertificates=true",
+          "mongodb://fc_admin:pass@localhost:27017/corev2?authSource=admin&replicaSet=rs0&directConnection=true&tls=true&tlsAllowInvalidCertificates=true",
       },
     },
   ],


### PR DESCRIPTION
**Problem**

Local dev config used legacy naming (`core-fca-low`, user `fc`) that diverged from the production setup, making it harder to reason about environment parity.

**Proposal**

Align the MongoDB database name and API user with prod: `corev2` and `proconnect-app-api-partner`. Updated docker-compose, entrypoint seed script, playwright webServer, and CI workflow accordingly.