### PR TITLE
📝 docs: remove obsolete authorization requirement for roles scope

### DIFF
--- a/src/pages/docs/fournisseur-service/roles.md
+++ b/src/pages/docs/fournisseur-service/roles.md
@@ -9,5 +9,3 @@ Il :
 - est vide sinon
 
 Le calcul de cette valeur est détaillé dans [ce code](https://github.com/proconnect-gouv/proconnect-identite/blob/main/packages/identite/src/services/organization/is-public-service.ts).
-
-Tous les Fournisseurs de Service de production créés après le 12 mai 2026 sont autorisés à demander ce scope par défaut. Pour les autres, vous pouvez en faire la demande par mail à support.partenaires@mail.proconnect.gouv.fr en indiquant le client ID de votre Fournisseur de Service.


### PR DESCRIPTION
**Problem**
The documentation still states that Service Providers must request authorization to receive the `roles` scope, even though it is now available to all Service Providers by default.

**Proposal**
Remove this outdated section from the documentation to reflect the current behavior.