### PR TITLE
docs(eidas): move shared eIDAS content to ressources/

### DIFF
--- a/src/pages/docs/fournisseur-identite/authentification-multifacteur.md
+++ b/src/pages/docs/fournisseur-identite/authentification-multifacteur.md
@@ -6,7 +6,7 @@ Certains Fournisseurs de Service (FS) exigent que leurs utilisateurs s'authentif
 
 Pour comprendre comment un FS configure cette exigence de son côté, consultez [la documentation dédiée aux Fournisseurs de Service](../fournisseur-service/double_authentification.md).
 
-Pour en savoir plus sur les niveaux d'assurance (`acr`) utilisés par ProConnect, consultez [la documentation dédiée](./niveaux-assurance-eidas.md).
+Pour savoir quelle méthode d'authentification correspond à chaque niveau demandé (`eidas2`, `eidas3`…), consultez [Niveaux d'assurance — Ce que cela signifie pour un FI](./niveaux-assurance-eidas.md#ce-que-cela-signifie-pour-un-fi).
 
 > [!CAUTION]
 > Ces niveaux sont provisoires et seront définitifs au T2 2026. Vous pouvez commencer à les implémenter pour être MFA-ready.

--- a/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
+++ b/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
@@ -1,39 +1,47 @@
 # Niveaux d'assurance (eidas) pour les Fournisseurs d'Identité
 
+> [!NOTE]
+> Pour en savoir plus sur la norme eIDAS à ProConnect, nous avons rédigé une ressource commune aux Fournisseurs d'Identité et Fournisseurs de Service disponible ici → [Norme eIDAS](../ressources/norme_eidas.md). Elle expliquera en détails avec des exemples les différents éléments de la norme.
+
 ## Les niveaux d'assurance (ACR)
 
-Pour indiquer le niveau d'assurance d'une authentification, ProConnect utilise l'attribut `acr` (Authentication Context Class Reference).
+ProConnect communique le niveau de confiance d'une authentification via l'attribut `acr`. Chaque niveau est défini selon trois axes :
 
-Les niveaux d'assurance sont définis selon trois axes : la qualité de l'identité, la méthode d'authentification, et le lien avec l'organisation.
+- **Identité** : quelle est la qualité de preuve de l'identité de l'utilisateur ?
+- **Authentification** : comment l'utilisateur s'est-il authentifié ?
+- **Organisation** : quel est le lien entre l'utilisateur et son organisation ?
 
-| Valeur `acr` | Identité              | Authentification      | Organisation                            |
-| ------------ | --------------------- | --------------------- | --------------------------------------- |
-| `eidas0`     | Faible ou déclarative | Simple (mot de passe) | Modération ou déclaratif                |
-| `eidas0-mfa` | Faible ou déclarative | **MFA**               | Modération ou déclaratif                |
-| `eidas1`     | Faible                | Simple (mot de passe) | Modération ou plus                      |
-| `eidas1-mfa` | Faible                | **MFA**               | Modération ou plus                      |
-| `eidas2`     | Substantielle         | **MFA**               | Lien certifié par une source officielle |
-| `eidas3`     | Élevée                | **MFA**               | Lien certifié par une source officielle |
+| Valeur `acr` | Identité              | Authentification                         | Organisation                            |
+| ------------ | --------------------- | ---------------------------------------- | --------------------------------------- |
+| `eidas0`     | Faible ou déclarative | Simple (mot de passe)                    | Modération ou déclaratif                |
+| `eidas0-mfa` | Faible ou déclarative | MFA (auto-géré)                          | Modération ou déclaratif                |
+| `eidas1`     | Faible                | Simple (mot de passe)                    | Modération ou plus                      |
+| `eidas1-mfa` | Faible                | MFA (auto-géré)                          | Modération ou plus                      |
+| `eidas2`     | Substantielle         | MFA (géré par l'organisation)            | Lien certifié par une source officielle |
+| `eidas3`     | Élevée                | MFA matérielle (géré par l'organisation) | Lien certifié par une source officielle |
 
-> [!NOTE]
-> `eidas2` et `eidas3` impliquent **toujours** une MFA. Il n'existe pas de variante simple-facteur pour ces niveaux. Pour en savoir plus sur l'authentification multifacteur, [voici la page dédiée](./authentification-multifacteur.md)
+## Ce que cela signifie pour un FI
 
-### Détail des niveaux eidas2 et eidas3
+En tant que Fournisseur d'Identité, vous maîtrisez les trois piliers : l'identité de vos agents est vérifiée à l'embarquement, et leur rattachement à l'organisation est certifié par vos processus RH. Ces deux piliers sont donc toujours au niveau maximum pour les niveaux eidas1, eidas2 et eidas3.
 
-**Lien certifié par une source officielle** désigne un processus d'embarquement RH : l'identité de la personne a été vérifiée à son arrivée (via des justificatifs ou un processus interne), puis elle a été rattachée à l'organisation dans l'annuaire (création de compte, remise des moyens d'authentification).
+En pratique, **le niveau que vous retournez est déterminé par la méthode d'authentification que vous proposez** :
 
-La distinction entre eidas2 et eidas3 porte sur le type de moyen de double authentification :
+| Méthode d'authentification              | Niveau retourné | Exemples                                           |
+| --------------------------------------- | --------------- | -------------------------------------------------- |
+| Simple (mot de passe)                   | `eidas1`        | Mot de passe seul                                  |
+| MFA auto-géré par l'agent              | `eidas1-mfa`    | TOTP configuré par l'agent sur son téléphone       |
+| MFA géré par l'organisation             | `eidas2`        | TOTP distribué par les RH, SMS OTP, push notification |
+| MFA matérielle géré par l'organisation  | `eidas3`        | Carte à puce + PIN, clé FIDO2 matérielle (YubiKey) |
 
-| Niveau   | Exemple de moyen d'authentification   |
-| -------- | ------------------------------------- |
-| `eidas2` | TOTP (application d'authentification) |
-| `eidas3` | Carte à puce avec code PIN            |
+Pour le détail des méthodes MFA qui atteignent eidas2 ou eidas3 (et pourquoi certaines n'atteignent pas eidas3), voir [Norme eIDAS — La méthode d'authentification](../ressources/norme_eidas.md#3-la-méthode-dauthentification).
 
-### Différence entre eidas1-mfa et eidas2
+Pour implémenter la MFA côté FI, voir [Authentification multi-facteur](./authentification-multifacteur.md).
 
-La distinction ne porte pas sur la robustesse technique du second facteur, mais sur **l'entité qui contrôle son cycle de vie** (distribution, association, révocation).
+### La distinction eidas1-mfa / eidas2
+
+La frontière ne porte pas sur la robustesse technique du second facteur, mais sur **qui contrôle son cycle de vie** (distribution, association, révocation) :
 
 | Niveau       | Contrôle du second facteur                             | Exemple                                                                             |
 | ------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | `eidas1-mfa` | L'agent gère lui-même (peut le changer, le transférer) | TOTP configuré par l'agent dans son application, transféré sur plusieurs téléphones |
-| `eidas2`     | L'organisation maîtrise l'intégralité du cycle de vie  | Yubikey distribuée par les RH, association faite par l'admin                        |
+| `eidas2`     | L'organisation maîtrise l'intégralité du cycle de vie  | YubiKey distribuée par les RH, association faite par l'admin                        |

--- a/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
+++ b/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
@@ -26,12 +26,12 @@ En tant que Fournisseur d'Identité, vous maîtrisez les trois piliers : l'ident
 
 En pratique, **le niveau que vous retournez est déterminé par la méthode d'authentification que vous proposez** :
 
-| Méthode d'authentification              | Niveau retourné | Exemples                                           |
-| --------------------------------------- | --------------- | -------------------------------------------------- |
-| Simple (mot de passe)                   | `eidas1`        | Mot de passe seul                                  |
-| MFA auto-géré par l'agent              | `eidas1-mfa`    | TOTP configuré par l'agent sur son téléphone       |
-| MFA géré par l'organisation             | `eidas2`        | TOTP distribué par les RH, SMS OTP, push notification |
-| MFA matérielle géré par l'organisation  | `eidas3`        | Carte à puce + PIN, clé FIDO2 matérielle (YubiKey) |
+| Méthode d'authentification             | Niveau retourné | Exemples                                              |
+| -------------------------------------- | --------------- | ----------------------------------------------------- |
+| Simple (mot de passe)                  | `eidas1`        | Mot de passe seul                                     |
+| MFA auto-géré par l'agent              | `eidas1-mfa`    | TOTP configuré par l'agent sur son téléphone          |
+| MFA géré par l'organisation            | `eidas2`        | TOTP distribué par les RH, SMS OTP, push notification |
+| MFA matérielle géré par l'organisation | `eidas3`        | Carte à puce + PIN, clé FIDO2 matérielle (YubiKey)    |
 
 Pour le détail des méthodes MFA qui atteignent eidas2 ou eidas3 (et pourquoi certaines n'atteignent pas eidas3), voir [Norme eIDAS — La méthode d'authentification](../ressources/norme_eidas.md#3-la-méthode-dauthentification).
 

--- a/src/pages/docs/fournisseur-identite/table_matieres.md
+++ b/src/pages/docs/fournisseur-identite/table_matieres.md
@@ -18,15 +18,16 @@ Avant toute chose, nous vous recommandons fortement de lire [notre page de proce
 
 → _Configurer votre FI, tester l'intégration et supporter la MFA_
 
-| Page                                                                 | Question                                                                                      |
-| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [Configuration](./configuration.md)                                  | Comment configurer OpenID Connect (OIDC) pour ProConnect en tant que Fournisseur d'Identité ? |
-| [Niveaux d'assurance (eidas)](./niveaux-assurance-eidas.md)          | Que signifient les niveaux eidas0, eidas1, eidas2, eidas3 ?                                   |
-| [Authentification multi-facteur](./authentification-multifacteur.md) | Comment supporter l'authentification multi-facteur (MFA) exigée par certains FS ?             |
-| [Test de configuration](./test-configuration-fi.md)                  | Comment tester la configuration de mon Fournisseur d'Identité ?                               |
-| [Format de l'userinfo](./format-user-info.md)                        | Quelles contraintes ProConnect applique-t-il sur les identités retournées par les userinfos ? |
-| [Certificats](./certificats_fi.md)                                   | Quels sont les certificats d'authentification utilisés par ProConnect ?                       |
-| [Référentiel IP](./referentiel-IP.md)                                | Quelles adresses IP dois-je autoriser pour que ProConnect puisse contacter mon FI ?           |
+| Page                                                                    | Question                                                                                                                                     |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Configuration](./configuration.md)                                     | Comment configurer OpenID Connect (OIDC) pour ProConnect en tant que Fournisseur d'Identité ?                                                |
+| [Niveaux d'assurance (eidas)](./niveaux-assurance-eidas.md)             | Que signifient les niveaux eidas0, eidas1, eidas2, eidas3 ?                                                                                  |
+| [Norme eIDAS](../ressources/norme_eidas.md) _(ressource commune FS/FI)_ | Quels sont les trois piliers de la norme eIDAS (identité, authentification, organisation), les méthodes MFA et le cas particulier d'eidas0 ? |
+| [Authentification multi-facteur](./authentification-multifacteur.md)    | Comment supporter l'authentification multi-facteur (MFA) exigée par certains FS ?                                                            |
+| [Test de configuration](./test-configuration-fi.md)                     | Comment tester la configuration de mon Fournisseur d'Identité ?                                                                              |
+| [Format de l'userinfo](./format-user-info.md)                           | Quelles contraintes ProConnect applique-t-il sur les identités retournées par les userinfos ?                                                |
+| [Certificats](./certificats_fi.md)                                      | Quels sont les certificats d'authentification utilisés par ProConnect ?                                                                      |
+| [Référentiel IP](./referentiel-IP.md)                                   | Quelles adresses IP dois-je autoriser pour que ProConnect puisse contacter mon FI ?                                                          |
 
 ## ⚙️ 3. Configurations spécifiques
 

--- a/src/pages/docs/fournisseur-service/niveaux-eidas.md
+++ b/src/pages/docs/fournisseur-service/niveaux-eidas.md
@@ -3,6 +3,10 @@
 > [!CAUTION]
 > Les niveaux ACR renvoyés par ProConnect sont actuellement en cours de définition en collaboration avec nos partenaires et l'ANSSI.
 
+> [!NOTE]
+> Pour en savoir plus sur la norme eIDAS à ProConnect, nous avons rédigé une ressource commune aux Fournisseurs d'Identité et Fournisseurs de Service disponible ici → [Norme eIDAS](../ressources/norme_eidas.md). Elle expliquera en détails avec des exemples les différents éléments de la norme.
+
+
 ## 1. Les niveaux eidas
 
 ProConnect communique le niveau de confiance d'une authentification via l'attribut `acr`. Chaque niveau est défini selon trois axes :
@@ -20,78 +24,6 @@ ProConnect communique le niveau de confiance d'une authentification via l'attrib
 | `eidas2`     | Substantielle         | MFA (géré par l'organisation)            | Lien certifié par une source officielle |
 | `eidas3`     | Élevée                | MFA matérielle (géré par l'organisation) | Lien certifié par une source officielle |
 
-Les niveaux eidas sont construits sur trois piliers indépendants. Comprendre chacun d'eux permet de choisir le niveau adapté à votre service.
-
-> [!NOTE]
-> Le niveau eidas retourné est déterminé par le pilier le plus faible. Un Fournisseur d'Identité aura vérifié l'**identité** de ses agents à un niveau élevé et le lien avec l'**organisation** est certifié par une source officielle, mais si la méthode d'**authentification** est un simple mot de passe, le niveau retourné sera `eidas1`, et non `eidas3`.
-
-### 1.1. La qualité de l'identité
-
-Le [règlement eIDAS (2015/1502)](https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:32015R1502&from=FR) définit trois niveaux de garantie pour l'identification électronique. Ils décrivent dans quelle mesure l'identité numérique d'un utilisateur a été vérifiée avant de lui être attribuée. ProConnect y ajoute un niveau déclaratif, en-dessous des niveaux eIDAS.
-
-| Qualité                 | Explication                                                                                                                                                                                                                          | Exemple                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| Déclarative             | L'utilisateur renseigne lui-même ses informations, sans aucune vérification externe.                                                                                                                                                 | Compte créé sans vérification d'identité                                                                      |
-| Faible _(eIDAS)_        | L'existence de l'identité peut être **présumée** à partir d'une source faisant autorité. Aucune vérification active n'est requise : on présume que la personne est bien celle qu'elle prétend être.                                  | Vérification d'identité avec FranceConnect                                                                    |
-| Substantielle _(eIDAS)_ | Il a été **vérifié** que la personne est en possession d'un document d'identité reconnu, dont l'authenticité a été contrôlée. Des mesures ont été prises pour minimiser le risque d'usurpation (perte, vol, expiration, révocation). | Vérification d'identité avec FranceConnect+                                                                   |
-| Élevée _(eIDAS)_        | Niveau substantiel, plus : la personne a été identifiée par comparaison de caractéristiques physiques (biométrie ou photographie) auprès d'une source faisant autorité.                                                              | Embarquement par un processus RH traditionnel ; Vérification d'identité avec FranceConnect+ et FranceIdentité |
-
-### 1.2. La méthode d'authentification
-
-Un facteur d'authentification appartient à l'une des trois catégories suivantes, telles que définies par le [règlement eIDAS (2015/1502)](https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:32015R1502&from=FR) :
-
-- **Connaissance** : quelque chose que l'on sait : mot de passe, code PIN
-- **Possession** : quelque chose que l'on possède : téléphone, clé physique, carte à puce
-- **Inhérent** : quelque chose que l'on est : empreinte digitale, reconnaissance faciale
-
-Une authentification multi-facteur (MFA) doit combiner au moins deux facteurs appartenant à des catégories différentes. Deux mots de passe ne constituent pas une MFA.
-
-Deux critères issus du règlement permettent de distinguer les niveaux MFA entre eux :
-
-- **Contrôle du facteur (section 2.2.1)** : peut-on _présumer_ que le second facteur est sous contrôle exclusif de la personne, ou la protection est-elle _fiable_ par construction ?
-- **Résistance aux attaques (section 2.3.1)** : le mécanisme résiste-t-il à un attaquant à potentiel _modéré_ ou _élevé_ ?
-
-| Méthode                                  | Explication                                                                                                                                                                                                            |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Simple                                   | Un seul facteur d'authentification.                                                                                                                                                                                    |
-| MFA (auto-géré)                          | Deux facteurs de catégories différentes. Contrôle : **présumé** exclusif. Résistance : attaquant à potentiel **modéré**. Le second facteur est configuré et géré par l'utilisateur lui-même.                           |
-| MFA (géré par l'organisation)            | Identique à MFA (auto-géré) du point de vue eIDAS, contrôle **présumé**, résistance **modérée**. Seule différence : l'organisation maîtrise le cycle de vie du second facteur (distribution, association, révocation). |
-| MFA matérielle (géré par l'organisation) | Deux facteurs de catégories différentes. Contrôle : **fiable** (le facteur est physique et sa clé ne peut pas être extraite). Résistance : attaquant à potentiel **élevé**.                                            |
-
-**Exemples commentés**
-
-Les exemples suivants illustrent pourquoi une méthode donnée atteint eidas2 mais pas eidas3, ou eidas3. La distinction repose sur les deux critères du règlement : garantie _présumée_ ou _fiable_ sur le contrôle du facteur, et résistance à un attaquant à potentiel _modéré_ ou _élevé_.
-
-| Méthode                                         | Niveau max      | Pourquoi pas l'autre                                                                                                                                      |
-| ----------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| TOTP (application authenticator)                | eidas2          | Le secret TOTP peut être sauvegardé et transféré sur un autre appareil → seulement _présumé_ sous contrôle exclusif. Ne résiste pas à un attaquant élevé. |
-| SMS OTP                                         | eidas2          | Vulnérable au SIM swapping et à l'interception SS7 → ne résiste pas à un attaquant élevé.                                                                 |
-| Push notification (ex. Microsoft Authenticator) | eidas2          | Dépend de la sécurité de l'appareil et du compte cloud associé → seulement _présumée_ sous contrôle exclusif.                                             |
-| Passkey synchronisé (ex. iCloud Keychain)       | eidas2          | La clé est synchronisée entre appareils → seulement _présumée_ sous contrôle exclusif. Ne résiste pas à un attaquant élevé.                               |
-| Passkey non-synchronisé (hardware-backed)       | eidas2 à eidas3 | Si la clé est ancrée dans la puce de l'appareil et non exportable, peut atteindre une garantie _fiable_. Dépend de l'implémentation.                      |
-| Carte à puce + PIN (ex. carte agent)            | eidas3          | La clé privée est ancrée dans la puce et ne peut pas être extraite → garantie _fiable_. Résiste aux attaquants à potentiel élevé.                         |
-| Clé FIDO2 matérielle (ex. YubiKey) + PIN        | eidas3          | Clé générée dans le secure element, non exportable → garantie _fiable_. Résiste aux attaquants à potentiel élevé.                                         |
-
-### 1.3. Le lien avec l'organisation
-
-| Lien                                    | Explication                                                                                                                                                                                                                                                                                |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Déclaratif                              | L'appartenance de l'utilisateur à son organisation est auto-déclarée.                                                                                                                                                                                                                      |
-| Modération                              | L'appartenance est validée par un tiers (administrateur, modérateur).                                                                                                                                                                                                                      |
-| Lien certifié par une source officielle | L'appartenance a été enregistrée et vérifiée auprès d'une source faisant autorité sur la base de procédures reconnues (processus RH formel : création de compte, rattachement dans l'annuaire, remise des moyens d'authentification). Le lien peut être suspendu ou révoqué à tout moment. |
-
-### 1.4. Le cas de `eidas0`
-
-`eidas0` regroupe les cas où l'identité est faible ou déclarative et le lien organisationnel est modération ou déclaratif. Ces deux axes ayant chacun deux valeurs possibles, voici comment les combinaisons sont interprétées :
-
-| Identité    | Organisation | Niveau                                                   |
-| ----------- | ------------ | -------------------------------------------------------- |
-| Déclarative | Déclaratif   | Non autorisé (les deux piliers sont au niveau minimal)   |
-| Déclarative | Modération   | `eidas0`                                                 |
-| Faible      | Déclaratif   | `eidas0`                                                 |
-| Faible      | Modération   | `eidas1` (les deux piliers atteignent le niveau suivant) |
-
-`eidas0` correspond donc aux cas intermédiaires : l'un des deux piliers est déclaratif tandis que l'autre atteint le niveau faible ou modération.
 
 ## 2. Comment exiger un niveau minimum ?
 

--- a/src/pages/docs/fournisseur-service/niveaux-eidas.md
+++ b/src/pages/docs/fournisseur-service/niveaux-eidas.md
@@ -6,7 +6,6 @@
 > [!NOTE]
 > Pour en savoir plus sur la norme eIDAS à ProConnect, nous avons rédigé une ressource commune aux Fournisseurs d'Identité et Fournisseurs de Service disponible ici → [Norme eIDAS](../ressources/norme_eidas.md). Elle expliquera en détails avec des exemples les différents éléments de la norme.
 
-
 ## 1. Les niveaux eidas
 
 ProConnect communique le niveau de confiance d'une authentification via l'attribut `acr`. Chaque niveau est défini selon trois axes :
@@ -23,7 +22,6 @@ ProConnect communique le niveau de confiance d'une authentification via l'attrib
 | `eidas1-mfa` | Faible                | MFA (auto-géré)                          | Modération ou plus                      |
 | `eidas2`     | Substantielle         | MFA (géré par l'organisation)            | Lien certifié par une source officielle |
 | `eidas3`     | Élevée                | MFA matérielle (géré par l'organisation) | Lien certifié par une source officielle |
-
 
 ## 2. Comment exiger un niveau minimum ?
 

--- a/src/pages/docs/fournisseur-service/table_matieres.md
+++ b/src/pages/docs/fournisseur-service/table_matieres.md
@@ -56,11 +56,12 @@ Nous vous recommandons de lire [notre page généraliste sur l'implémentation t
 
 → _Quel niveau de confiance et de sécurité puis-je exiger de ProConnect ?_
 
-| Page                                                    | Question                                                                                |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| [Niveaux eidas](./niveaux-eidas.md)                     | Que signifient les niveaux eidas et comment en choisir un ?                             |
-| [Double authentification](./double_authentification.md) | Comment forcer la double authentification (2FA) / Multifacteur Authentification (MFA) ? |
-| [Niveaux ACR](./niveaux-acr.md)                         | Comment exiger un niveau minimum dans mes requêtes et lire le claim `amr` ?             |
+| Page                                                                    | Question                                                                                                                                     |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Niveaux eidas](./niveaux-eidas.md)                                     | Que signifient les niveaux eidas et comment en choisir un ?                                                                                  |
+| [Norme eIDAS](../ressources/norme_eidas.md) _(ressource commune FS/FI)_ | Quels sont les trois piliers de la norme eIDAS (identité, authentification, organisation), les méthodes MFA et le cas particulier d'eidas0 ? |
+| [Double authentification](./double_authentification.md)                 | Comment forcer la double authentification (2FA) / Multifacteur Authentification (MFA) ?                                                      |
+| [Niveaux ACR](./niveaux-acr.md)                                         | Comment exiger un niveau minimum dans mes requêtes et lire le claim `amr` ?                                                                  |
 
 ## 🏢 6. Certification dirigeant
 

--- a/src/pages/docs/ressources/norme_eidas.md
+++ b/src/pages/docs/ressources/norme_eidas.md
@@ -1,0 +1,96 @@
+# Norme eIDAS : niveaux d'assurance
+
+Cette page décrit les niveaux d'assurance eIDAS tels qu'utilisés par ProConnect. Elle est commune aux deux types de partenaires :
+
+- [Fournisseurs de Service → Niveaux eIDAS](../fournisseur-service/niveaux-eidas.md)
+- [Fournisseurs d'Identité → Niveaux d'assurance (eIDAS)](../fournisseur-identite/niveaux-assurance-eidas.md)
+
+## 1. Les niveaux eIDAS
+
+ProConnect communique le niveau de confiance d'une authentification via l'attribut `acr`. Chaque niveau est défini selon trois axes :
+
+- **Identité** : quelle est la qualité de preuve de l'identité de l'utilisateur ?
+- **Authentification** : comment l'utilisateur s'est-il authentifié ?
+- **Organisation** : quel est le lien entre l'utilisateur et son organisation ?
+
+| Valeur `acr` | Identité              | Authentification                         | Organisation                            |
+| ------------ | --------------------- | ---------------------------------------- | --------------------------------------- |
+| `eidas0`     | Faible ou déclarative | Simple (mot de passe)                    | Modération ou déclaratif                |
+| `eidas0-mfa` | Faible ou déclarative | MFA (auto-géré)                          | Modération ou déclaratif                |
+| `eidas1`     | Faible                | Simple (mot de passe)                    | Modération ou plus                      |
+| `eidas1-mfa` | Faible                | MFA (auto-géré)                          | Modération ou plus                      |
+| `eidas2`     | Substantielle         | MFA (géré par l'organisation)            | Lien certifié par une source officielle |
+| `eidas3`     | Élevée                | MFA matérielle (géré par l'organisation) | Lien certifié par une source officielle |
+
+Les niveaux eIDAS sont construits sur trois piliers indépendants. Comprendre chacun d'eux permet de choisir le niveau adapté à votre contexte.
+
+> [!NOTE]
+> Le niveau eIDAS retourné est déterminé par le pilier le plus faible. Un Fournisseur d'Identité aura vérifié l'**identité** de ses agents à un niveau élevé et le lien avec l'**organisation** est certifié par une source officielle, mais si la méthode d'**authentification** est un simple mot de passe, le niveau retourné sera `eidas1`, et non `eidas3`.
+
+## 2. La qualité de l'identité
+
+Le [règlement eIDAS (2015/1502)](https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:32015R1502&from=FR) définit trois niveaux de garantie pour l'identification électronique. Ils décrivent dans quelle mesure l'identité numérique d'un utilisateur a été vérifiée avant de lui être attribuée. ProConnect y ajoute un niveau déclaratif, en-dessous des niveaux eIDAS.
+
+| Qualité                 | Explication                                                                                                                                                                                                                          | Exemple                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Déclarative             | L'utilisateur renseigne lui-même ses informations, sans aucune vérification externe.                                                                                                                                                 | Compte créé sans vérification d'identité                                                                      |
+| Faible _(eIDAS)_        | L'existence de l'identité peut être **présumée** à partir d'une source faisant autorité. Aucune vérification active n'est requise : on présume que la personne est bien celle qu'elle prétend être.                                  | Vérification d'identité avec FranceConnect                                                                    |
+| Substantielle _(eIDAS)_ | Il a été **vérifié** que la personne est en possession d'un document d'identité reconnu, dont l'authenticité a été contrôlée. Des mesures ont été prises pour minimiser le risque d'usurpation (perte, vol, expiration, révocation). | Vérification d'identité avec FranceConnect+                                                                   |
+| Élevée _(eIDAS)_        | Niveau substantiel, plus : la personne a été identifiée par comparaison de caractéristiques physiques (biométrie ou photographie) auprès d'une source faisant autorité.                                                              | Embarquement par un processus RH traditionnel ; Vérification d'identité avec FranceConnect+ et FranceIdentité |
+
+## 3. La méthode d'authentification
+
+Un facteur d'authentification appartient à l'une des trois catégories suivantes, telles que définies par le [règlement eIDAS (2015/1502)](https://eur-lex.europa.eu/legal-content/FR/TXT/PDF/?uri=CELEX:32015R1502&from=FR) :
+
+- **Connaissance** : quelque chose que l'on sait : mot de passe, code PIN
+- **Possession** : quelque chose que l'on possède : téléphone, clé physique, carte à puce
+- **Inhérent** : quelque chose que l'on est : empreinte digitale, reconnaissance faciale
+
+Une authentification multi-facteur (MFA) doit combiner au moins deux facteurs appartenant à des catégories différentes. Deux mots de passe ne constituent pas une MFA.
+
+Deux critères issus du règlement permettent de distinguer les niveaux MFA entre eux :
+
+- **Contrôle du facteur (section 2.2.1)** : peut-on _présumer_ que le second facteur est sous contrôle exclusif de la personne, ou la protection est-elle _fiable_ par construction ?
+- **Résistance aux attaques (section 2.3.1)** : le mécanisme résiste-t-il à un attaquant à potentiel _modéré_ ou _élevé_ ?
+
+| Méthode                                  | Explication                                                                                                                                                                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Simple                                   | Un seul facteur d'authentification.                                                                                                                                                                                    |
+| MFA (auto-géré)                          | Deux facteurs de catégories différentes. Contrôle : **présumé** exclusif. Résistance : attaquant à potentiel **modéré**. Le second facteur est configuré et géré par l'utilisateur lui-même.                           |
+| MFA (géré par l'organisation)            | Identique à MFA (auto-géré) du point de vue eIDAS, contrôle **présumé**, résistance **modérée**. Seule différence : l'organisation maîtrise le cycle de vie du second facteur (distribution, association, révocation). |
+| MFA matérielle (géré par l'organisation) | Deux facteurs de catégories différentes. Contrôle : **fiable** (le facteur est physique et sa clé ne peut pas être extraite). Résistance : attaquant à potentiel **élevé**.                                            |
+
+### 3.1. Exemples commentés
+
+Les exemples suivants illustrent pourquoi une méthode donnée atteint eidas2 mais pas eidas3, ou eidas3. La distinction repose sur les deux critères du règlement : garantie _présumée_ ou _fiable_ sur le contrôle du facteur, et résistance à un attaquant à potentiel _modéré_ ou _élevé_.
+
+| Méthode                                         | Niveau max      | Pourquoi pas l'autre                                                                                                                                      |
+| ----------------------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TOTP (application authenticator)                | eidas2          | Le secret TOTP peut être sauvegardé et transféré sur un autre appareil → seulement _présumé_ sous contrôle exclusif. Ne résiste pas à un attaquant élevé. |
+| SMS OTP                                         | eidas2          | Vulnérable au SIM swapping et à l'interception SS7 → ne résiste pas à un attaquant élevé.                                                                 |
+| Push notification (ex. Microsoft Authenticator) | eidas2          | Dépend de la sécurité de l'appareil et du compte cloud associé → seulement _présumée_ sous contrôle exclusif.                                             |
+| Passkey synchronisé (ex. iCloud Keychain)       | eidas2          | La clé est synchronisée entre appareils → seulement _présumée_ sous contrôle exclusif. Ne résiste pas à un attaquant élevé.                               |
+| Passkey non-synchronisé (hardware-backed)       | eidas2 à eidas3 | Si la clé est ancrée dans la puce de l'appareil et non exportable, peut atteindre une garantie _fiable_. Dépend de l'implémentation.                      |
+| Carte à puce + PIN (ex. carte agent)            | eidas3          | La clé privée est ancrée dans la puce et ne peut pas être extraite → garantie _fiable_. Résiste aux attaquants à potentiel élevé.                         |
+| Clé FIDO2 matérielle (ex. YubiKey) + PIN        | eidas3          | Clé générée dans le secure element, non exportable → garantie _fiable_. Résiste aux attaquants à potentiel élevé.                                         |
+
+## 4. Le lien avec l'organisation
+
+| Lien                                    | Explication                                                                                                                                                                                                                                                                                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Déclaratif                              | L'appartenance de l'utilisateur à son organisation est auto-déclarée.                                                                                                                                                                                                                      |
+| Modération                              | L'appartenance est validée par un tiers (administrateur, modérateur).                                                                                                                                                                                                                      |
+| Lien certifié par une source officielle | L'appartenance a été enregistrée et vérifiée auprès d'une source faisant autorité sur la base de procédures reconnues (processus RH formel : création de compte, rattachement dans l'annuaire, remise des moyens d'authentification). Le lien peut être suspendu ou révoqué à tout moment. |
+
+## 5. Le cas de `eidas0`
+
+`eidas0` regroupe les cas où l'identité est faible ou déclarative et le lien organisationnel est modération ou déclaratif. Ces deux axes ayant chacun deux valeurs possibles, voici comment les combinaisons sont interprétées :
+
+| Identité    | Organisation | Niveau                                                   |
+| ----------- | ------------ | -------------------------------------------------------- |
+| Déclarative | Déclaratif   | Non autorisé (les deux piliers sont au niveau minimal)   |
+| Déclarative | Modération   | `eidas0`                                                 |
+| Faible      | Déclaratif   | `eidas0`                                                 |
+| Faible      | Modération   | `eidas1` (les deux piliers atteignent le niveau suivant) |
+
+`eidas0` correspond donc aux cas intermédiaires : l'un des deux piliers est déclaratif tandis que l'autre atteint le niveau faible ou modération.


### PR DESCRIPTION
## Summary

- Crée `docs/ressources/norme_eidas.md` : ressource commune FS/FI avec l'explication complète de la norme eIDAS (trois piliers, cas eidas0, exemples de méthodes MFA)
- Simplifie la page FS (`niveaux-eidas.md`) : on garde le tableau récapitulatif et la section technique (comment exiger un niveau), le reste pointe vers la ressource commune
- Restructure la page FI (`niveaux-assurance-eidas.md`) : nouvelle section « Ce que cela signifie pour un FI » expliquant que le niveau retourné dépend uniquement de la méthode d'authentification, avec tableau pratique méthode → niveau et exemples
- Met à jour `authentification-multifacteur.md` : lien vers la section FI du mapping plutôt qu'un lien générique