### PR TITLE
docs(eidas): supprimer la distinction "géré par l'organisation" pour eidas2/eidas3

### DIFF
--- a/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
+++ b/src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md
@@ -11,14 +11,14 @@ ProConnect communique le niveau de confiance d'une authentification via l'attrib
 - **Authentification** : comment l'utilisateur s'est-il authentifié ?
 - **Organisation** : quel est le lien entre l'utilisateur et son organisation ?
 
-| Valeur `acr` | Identité              | Authentification                         | Organisation                            |
-| ------------ | --------------------- | ---------------------------------------- | --------------------------------------- |
-| `eidas0`     | Faible ou déclarative | Simple (mot de passe)                    | Modération ou déclaratif                |
-| `eidas0-mfa` | Faible ou déclarative | MFA (auto-géré)                          | Modération ou déclaratif                |
-| `eidas1`     | Faible                | Simple (mot de passe)                    | Modération ou plus                      |
-| `eidas1-mfa` | Faible                | MFA (auto-géré)                          | Modération ou plus                      |
-| `eidas2`     | Substantielle         | MFA (géré par l'organisation)            | Lien certifié par une source officielle |
-| `eidas3`     | Élevée                | MFA matérielle (géré par l'organisation) | Lien certifié par une source officielle |
+| Valeur `acr` | Identité              | Authentification      | Organisation                            |
+| ------------ | --------------------- | --------------------- | --------------------------------------- |
+| `eidas0`     | Faible ou déclarative | Simple (mot de passe) | Modération ou déclaratif                |
+| `eidas0-mfa` | Faible ou déclarative | MFA (auto-géré)       | Modération ou déclaratif                |
+| `eidas1`     | Faible                | Simple (mot de passe) | Modération ou plus                      |
+| `eidas1-mfa` | Faible                | MFA (auto-géré)       | Modération ou plus                      |
+| `eidas2`     | Substantielle         | MFA forte             | Lien certifié par une source officielle |
+| `eidas3`     | Élevée                | MFA forte matérielle  | Lien certifié par une source officielle |
 
 ## Ce que cela signifie pour un FI
 
@@ -26,12 +26,12 @@ En tant que Fournisseur d'Identité, vous maîtrisez les trois piliers : l'ident
 
 En pratique, **le niveau que vous retournez est déterminé par la méthode d'authentification que vous proposez** :
 
-| Méthode d'authentification                     | Niveau retourné | Exemples                                           |
-| ---------------------------------------------- | --------------- | -------------------------------------------------- |
-| Simple (mot de passe)                          | `eidas1`        | Mot de passe seul                                  |
-| MFA faible (géré par l'agent)                  | `eidas1-mfa`    | SMS OTP                                            |
-| MFA forte (géré par l'organisation)            | `eidas2`        | TOTP distribué par les RH, push notification       |
-| MFA forte matérielle (géré par l'organisation) | `eidas3`        | Carte à puce + PIN, clé FIDO2 matérielle (YubiKey) |
+| Méthode d'authentification    | Niveau retourné | Exemples                                           |
+| ----------------------------- | --------------- | -------------------------------------------------- |
+| Simple (mot de passe)         | `eidas1`        | Mot de passe seul                                  |
+| MFA faible (géré par l'agent) | `eidas1-mfa`    | SMS OTP                                            |
+| MFA forte                     | `eidas2`        | TOTP, push notification, passkey                   |
+| MFA forte matérielle          | `eidas3`        | Carte à puce + PIN, clé FIDO2 matérielle (YubiKey) |
 
 Pour le détail des méthodes MFA qui atteignent eidas2 ou eidas3 (et pourquoi certaines n'atteignent pas eidas3), voir [Norme eIDAS — La méthode d'authentification](../ressources/norme_eidas.md#3-la-méthode-dauthentification).
 
@@ -39,12 +39,11 @@ Pour implémenter la MFA côté FI, voir [Authentification multi-facteur](./auth
 
 ### La distinction eidas1-mfa / eidas2
 
-La frontière repose sur deux critères cumulatifs pour eidas2 :
+La frontière repose sur la force cryptographique du second facteur :
 
 - **Force cryptographique** (Guide ANSSI) : eidas2 requiert un facteur cryptographiquement fort (TOTP, FIDO2…). Un SMS OTP, canal non sécurisé, n'y atteint pas.
-- **Cycle de vie géré par l'organisation** : à eidas2, l'organisation maîtrise la distribution, l'association et la révocation du second facteur.
 
-| Niveau       | Second facteur                    | Cycle de vie            | Exemple                   |
-| ------------ | --------------------------------- | ----------------------- | ------------------------- |
-| `eidas1-mfa` | MFA faible (pas de crypto fort)   | Géré par l'agent        | SMS OTP                   |
-| `eidas2`     | MFA forte (protocole crypto fort) | Géré par l'organisation | TOTP distribué par les RH |
+| Niveau       | Second facteur                    | Exemple                          |
+| ------------ | --------------------------------- | -------------------------------- |
+| `eidas1-mfa` | MFA faible (pas de crypto fort)   | SMS OTP                          |
+| `eidas2`     | MFA forte (protocole crypto fort) | TOTP, push notification, passkey |

--- a/src/pages/docs/fournisseur-service/niveaux-eidas.md
+++ b/src/pages/docs/fournisseur-service/niveaux-eidas.md
@@ -14,14 +14,14 @@ ProConnect communique le niveau de confiance d'une authentification via l'attrib
 - **Authentification** : comment l'utilisateur s'est-il authentifié ?
 - **Organisation** : quel est le lien entre l'utilisateur et son organisation ?
 
-| Valeur `acr` | Identité              | Authentification                               | Organisation                            |
-| ------------ | --------------------- | ---------------------------------------------- | --------------------------------------- |
-| `eidas0`     | Faible ou déclarative | Simple (mot de passe)                          | Modération ou déclaratif                |
-| `eidas0-mfa` | Faible ou déclarative | MFA faible                                     | Modération ou déclaratif                |
-| `eidas1`     | Faible                | Simple (mot de passe)                          | Modération ou plus                      |
-| `eidas1-mfa` | Faible                | MFA faible                                     | Modération ou plus                      |
-| `eidas2`     | Substantielle         | MFA forte (géré par l'organisation)            | Lien certifié par une source officielle |
-| `eidas3`     | Élevée                | MFA forte matérielle (géré par l'organisation) | Lien certifié par une source officielle |
+| Valeur `acr` | Identité              | Authentification      | Organisation                            |
+| ------------ | --------------------- | --------------------- | --------------------------------------- |
+| `eidas0`     | Faible ou déclarative | Simple (mot de passe) | Modération ou déclaratif                |
+| `eidas0-mfa` | Faible ou déclarative | MFA faible            | Modération ou déclaratif                |
+| `eidas1`     | Faible                | Simple (mot de passe) | Modération ou plus                      |
+| `eidas1-mfa` | Faible                | MFA faible            | Modération ou plus                      |
+| `eidas2`     | Substantielle         | MFA forte             | Lien certifié par une source officielle |
+| `eidas3`     | Élevée                | MFA forte matérielle  | Lien certifié par une source officielle |
 
 ## 2. Comment exiger un niveau minimum ?
 

--- a/src/pages/docs/ressources/norme_eidas.md
+++ b/src/pages/docs/ressources/norme_eidas.md
@@ -13,14 +13,14 @@ ProConnect communique le niveau de confiance d'une authentification via l'attrib
 - **Authentification** : comment l'utilisateur s'est-il authentifié ?
 - **Organisation** : quel est le lien entre l'utilisateur et son organisation ?
 
-| Valeur `acr` | Identité              | Authentification                               | Organisation                            |
-| ------------ | --------------------- | ---------------------------------------------- | --------------------------------------- |
-| `eidas0`     | Faible ou déclarative | Simple (mot de passe)                          | Modération ou déclaratif                |
-| `eidas0-mfa` | Faible ou déclarative | MFA faible                                     | Modération ou déclaratif                |
-| `eidas1`     | Faible                | Simple (mot de passe)                          | Modération ou plus                      |
-| `eidas1-mfa` | Faible                | MFA faible                                     | Modération ou plus                      |
-| `eidas2`     | Substantielle         | MFA forte (géré par l'organisation)            | Lien certifié par une source officielle |
-| `eidas3`     | Élevée                | MFA forte matérielle (géré par l'organisation) | Lien certifié par une source officielle |
+| Valeur `acr` | Identité              | Authentification      | Organisation                            |
+| ------------ | --------------------- | --------------------- | --------------------------------------- |
+| `eidas0`     | Faible ou déclarative | Simple (mot de passe) | Modération ou déclaratif                |
+| `eidas0-mfa` | Faible ou déclarative | MFA faible            | Modération ou déclaratif                |
+| `eidas1`     | Faible                | Simple (mot de passe) | Modération ou plus                      |
+| `eidas1-mfa` | Faible                | MFA faible            | Modération ou plus                      |
+| `eidas2`     | Substantielle         | MFA forte             | Lien certifié par une source officielle |
+| `eidas3`     | Élevée                | MFA forte matérielle  | Lien certifié par une source officielle |
 
 Les niveaux eIDAS sont construits sur trois piliers indépendants. Comprendre chacun d'eux permet de choisir le niveau adapté à votre contexte.
 
@@ -56,12 +56,12 @@ Trois critères permettent de distinguer les niveaux MFA entre eux :
 - **Contrôle du facteur** (eIDAS 2.2.1) : peut-on _présumer_ que le second facteur est sous contrôle exclusif de la personne, ou la protection est-elle _fiable_ par construction ?
 - **Résistance aux attaques** (eIDAS 2.3.1) : le mécanisme résiste-t-il à un attaquant à potentiel _modéré_ ou _élevé_ ?
 
-| Méthode                                        | Explication                                                                                                                                                                                                     |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Simple                                         | Un seul facteur d'authentification.                                                                                                                                                                             |
-| MFA faible                                     | Deux facteurs de catégories différentes. Aucun n'est cryptographiquement fort. Le second facteur est géré par l'utilisateur.                                                                                    |
-| MFA forte (géré par l'organisation)            | Deux facteurs de catégories différentes. Au moins un facteur est cryptographiquement fort (TOTP, FIDO2…). Contrôle : _présumé_ exclusif. Résistance : attaquant _modéré_. Cycle de vie géré par l'organisation. |
-| MFA forte matérielle (géré par l'organisation) | Deux facteurs de catégories différentes. Le second facteur est physique, sa clé est ancrée dans un composant de sécurité et ne peut pas être extraite. Contrôle : _fiable_. Résistance : attaquant _élevé_.     |
+| Méthode              | Explication                                                                                                                                                                                                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Simple               | Un seul facteur d'authentification.                                                                                                                                                                         |
+| MFA faible           | Deux facteurs de catégories différentes. Aucun n'est cryptographiquement fort. Le second facteur est géré par l'utilisateur.                                                                                |
+| MFA forte            | Deux facteurs de catégories différentes. Au moins un facteur est cryptographiquement fort (TOTP, FIDO2…). Contrôle : _présumé_ exclusif. Résistance : attaquant _modéré_.                                   |
+| MFA forte matérielle | Deux facteurs de catégories différentes. Le second facteur est physique, sa clé est ancrée dans un composant de sécurité et ne peut pas être extraite. Contrôle : _fiable_. Résistance : attaquant _élevé_. |
 
 ### 3.1. Exemples commentés
 


### PR DESCRIPTION
## Summary

- Supprime `(géré par l'organisation)` des labels eidas2 et eidas3 dans toutes les tables ACR
- Retire le critère "Cycle de vie géré par l'organisation" de la distinction eidas1-mfa / eidas2 — seule la force cryptographique du second facteur reste
- Simplifie la table de comparaison dans `niveaux-assurance-eidas.md` (colonne *Cycle de vie* supprimée)

## Fichiers modifiés

- `src/pages/docs/ressources/norme_eidas.md`
- `src/pages/docs/fournisseur-service/niveaux-eidas.md`
- `src/pages/docs/fournisseur-identite/niveaux-assurance-eidas.md`