### PR TITLE
Update double authentication documentation

### DIFF
--- a/src/pages/docs/fournisseur-service/double_authentification.md
+++ b/src/pages/docs/fournisseur-service/double_authentification.md
@@ -2,7 +2,6 @@
 
 > [!CAUTION]
 > La double authentification n’est pas supportée par tous les fournisseurs d’identité de la fédération ProConnect. Avant de forcer la 2FA sur votre service, vérifiez que les fournisseurs d’identité de vos utilisateurs supportent bien le niveau d’assurance requis.<br><br>
-> La liste des fournisseurs d’identité compatibles est disponible sur [cette page](https://grist.numerique.gouv.fr/o/docs/3kQ829mp7bTy/ProConnect-Configuration-des-FI-et-FS/p/5).<br><br>
 > Si vous souhaitez en savoir plus sur la compatibilité 2FA ou son implémentation technique, contactez l’équipe technique partenaires à : support.partenaires@mail.proconnect.gouv.fr.
 
 ## 1. Vue d'ensemble


### PR DESCRIPTION
Removed an outdated link to the list of compatible identity providers.