### PR TITLE
🔧 Replace non-standard TOTP AMR value

### DIFF
--- a/src/pages/docs/fournisseur-service/niveaux-acr.md
+++ b/src/pages/docs/fournisseur-service/niveaux-acr.md
@@ -65,7 +65,7 @@ ProConnect Identité peut renvoyer différentes valeurs `amr`, éventuellement c
 
 - `mail` : authentification via un lien de connexion (« lien magique »).
 
-- `totp` : authentification par application « authenticator » (ex. FreeOTP).
+- `otp` : authentification par application « authenticator » (ex. FreeOTP).
 
 - `pop` : authentification par clé d’accès (Passkey).
 

--- a/src/pages/docs/ressources/claim_amr.md
+++ b/src/pages/docs/ressources/claim_amr.md
@@ -14,7 +14,7 @@ Les valeurs possibles pour `amr` sont les suivantes :
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | pwd        | Authentification par mot de passe. En complément d'un mot de passe, l'utilisateur a authentifié son navigateur avec un one-time password envoyé par mail |
 | mail       | Authentification par lien de connexion "lien magique".                                                                                                   |
-| totp       | Authentification avec une application "authenticator" comme FreeOTP.                                                                                     |
+| otp        | Authentification avec une application "authenticator" comme FreeOTP.                                                                                     |
 | pop        | Authentification avec une clé d'accès (Passkey) ou carte agent.                                                                                          |
 | mfa        | Authentification à deux facteurs.                                                                                                                        |
 


### PR DESCRIPTION
**Problem**

When a user authenticates with TOTP, we return `totp` as an authentication method reference in the OIDC `amr` claim.

This value is not standardized, despite the existing comment stating otherwise.  RFC 8176 defines `otp`, but not `totp`: https://datatracker.ietf.org/doc/html/rfc8176#section-2.

This typo dates back to the introduction of the feature: https://github.com/proconnect-gouv/proconnect-identite/commit/c7722b87943fc064c1020bcb8f2e3b02203c315e.

**Proposal**

Use `otp` instead of `totp`, as specified by RFC 8176.

This change is related to
https://github.com/proconnect-gouv/proconnect-identite/pull/2012.