### PR TITLE
📝 Update the mail AMR definition

### DIFF
--- a/src/pages/docs/fournisseur-service/niveaux-acr.md
+++ b/src/pages/docs/fournisseur-service/niveaux-acr.md
@@ -61,9 +61,9 @@ claims={
 
 ProConnect Identité peut renvoyer différentes valeurs `amr`, éventuellement combinées :
 
-- `pwd` : authentification par mot de passe (en complément, un OTP peut être envoyé par e-mail si le navigateur utilisé n’est pas enrôlé).
+- `pwd` : authentification par mot de passe.
 
-- `mail` : authentification via un lien de connexion (« lien magique »).
+- `mail` : authentification avec confirmation par email.
 
 - `otp` : authentification par application « authenticator » (ex. FreeOTP).
 

--- a/src/pages/docs/ressources/claim_amr.md
+++ b/src/pages/docs/ressources/claim_amr.md
@@ -13,7 +13,7 @@ Les valeurs possibles pour `amr` sont les suivantes :
 | valeur amr | description                                                                                                                                              |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | pwd        | Authentification par mot de passe. En complément d'un mot de passe, l'utilisateur a authentifié son navigateur avec un one-time password envoyé par mail |
-| mail       | Authentification par lien de connexion "lien magique".                                                                                                   |
+| mail       | Confirmation par email.                                                                                                                                  |
 | otp        | Authentification avec une application "authenticator" comme FreeOTP.                                                                                     |
 | pop        | Authentification avec une clé d'accès (Passkey) ou carte agent.                                                                                          |
 | mfa        | Authentification à deux facteurs.                                                                                                                        |


### PR DESCRIPTION
**Problem**

The `mail` AMR does not have the same definition as in the FranceConnect
AMR documentation, despite explicitly referring to it.

Additionally, this AMR is currently used in ProConnect Identité only for
magic-link authentication, even though its definition also covers email
OTP authentication.

**Proposal**

Align the `mail` AMR definition with the FranceConnect definition.

Also add the `mail` AMR when a user authenticates with an email OTP.