### PR TITLE
🐛 fix: prevent users from attempting self-deletion

### DIFF
--- a/src/components/EditableList.tsx
+++ b/src/components/EditableList.tsx
@@ -14,6 +14,7 @@ type Props = {
   validateInput: (input: string) => boolean;
   inputValidationErrorMessage: string;
   tableTitle: string;
+  computeIsLineDeletable?: (item: string) => boolean;
 };
 
 export const EditableList = ({
@@ -26,6 +27,7 @@ export const EditableList = ({
   validateInput,
   inputValidationErrorMessage,
   tableTitle,
+  computeIsLineDeletable,
 }: Props) => {
   const [inputText, setInputText] = useState<string>("");
   const [inputError, setInputError] = useState<string | null>(null);
@@ -80,6 +82,7 @@ export const EditableList = ({
                 iconId="fr-icon-delete-bin-line"
                 onClick={() => removeItemFromArray(i)}
                 title="Supprimer cette ligne"
+                disabled={computeIsLineDeletable ? !computeIsLineDeletable(item) : false}
               >
                 Supprimer
               </Button>,

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -29,7 +29,13 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   try {
     const app = await pcdbClient.getOidcClient(id, session.user.email);
-    return { props: { app, isYourApplicationsServiceDisabled } };
+    return {
+      props: {
+        app,
+        isYourApplicationsServiceDisabled,
+        userEmail: session.user.email,
+      },
+    };
   } catch {
     return { notFound: true };
   }
@@ -56,9 +62,11 @@ const URL_PATTERN = /^https?:\/\/[^/].+$/;
 export default function AppDetailPage({
   app,
   isYourApplicationsServiceDisabled,
+  userEmail,
 }: {
   app: OidcClient;
   isYourApplicationsServiceDisabled: boolean;
+  userEmail: string;
 }) {
   const [data, setData] = useState(app);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -300,6 +308,7 @@ export default function AppDetailPage({
                 inputValidationErrorMessage="Veuillez saisir une adresse e-mail valide."
                 validateInput={(input) => EMAIL_PATTERN.test(input)}
                 tableTitle="Liste des personnes collaboratrices"
+                computeIsLineDeletable={(item) => item !== userEmail}
               />
             </div>
 


### PR DESCRIPTION
**Problem**
Users are presented with the option to delete their own account, but attempting to do so results in a `422` error.

**Proposal**
Remove the self-deletion option from the user interface.