### PR TITLE
🧪 test: validate npm prune compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           NEXT_PUBLIC_BASE_PATH: ""
           NODE_ENV: production
 
+      - name: 🔥 Prune dev dependencies
+        run: npm prune --omit=dev
+
       - name: 💾 Save app dependencies cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6

--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
     "typescript": "5.7.3",
     "unist-util-visit": "^5.0.0"
   },
+  "overrides": {
+    "nodemailer": "^9.0.1"
+  },
   "optionalDependencies": {
     "@swc/core-linux-x64-gnu": "^1.10.12"
   },


### PR DESCRIPTION
**Problem**
The Scalingo buildpack runs `npm prune`, while our test suite only validates installations using `npm ci`.

**Proposal**
Add a CI test that runs `npm prune` to ensure the application can be installed successfully in the same way as on Scalingo.