### PR TITLE
✨ feat: announce ProConnect migration in Partner Portal

### DIFF
--- a/src/components/ClosableNotice.tsx
+++ b/src/components/ClosableNotice.tsx
@@ -1,0 +1,18 @@
+"use client";
+import Notice, { NoticeProps } from "@codegouvfr/react-dsfr/Notice";
+import { useEffect, useState } from "react";
+
+export function ClosableNotice({ id: noticeId, ...props }: NoticeProps & { id: string }) {
+  useEffect(() => {
+    const storedIsClosed = localStorage?.getItem(`closable-notice-closed-${noticeId}`) === "true";
+    setIsClosed(storedIsClosed);
+  }, [noticeId]);
+
+  const [isClosed, setIsClosed] = useState(true);
+  return <Notice {...props} isClosed={isClosed} isClosable onClose={close} />;
+
+  function close() {
+    setIsClosed(true);
+    localStorage?.setItem(`closable-notice-closed-${noticeId}`, "true");
+  }
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { createEmotionSsrAdvancedApproach } from "tss-react/next";
 import { init } from "@socialgouv/matomo-next";
 import { DefaultSeo } from "next-seo";
 
+import { ClosableNotice } from "@/components/ClosableNotice";
 import { DocsLayoutFactory } from "../layouts/docs";
 import { PageLayout } from "../layouts/page";
 
@@ -84,6 +85,12 @@ function App({ Component, pageProps: { session, ...pageProps }, router }: AppPro
           flexDirection: "column",
         }}
       >
+        <ClosableNotice
+          id="proconnect-will-replace-magic-link-notice"
+          title="La connexion à votre Espace Partenaires se renforce."
+          severity="info"
+          description="ProConnect remplacera bientôt la connexion par lien de connexion. Assurez-vous que vos applications restent accessibles en utilisant la nouvelle fonctionnalité d’ajout de personnes collaboratrices."
+        />
         <Layout>
           <Component {...pageProps} />
         </Layout>

--- a/src/pages/apps/[id].tsx
+++ b/src/pages/apps/[id].tsx
@@ -193,7 +193,7 @@ export default function AppDetailPage({
               </div>
             </div>
 
-            <div className={fr.cx("fr-mb-10v")}>
+            <div className={fr.cx("fr-mb-12v")}>
               <Input
                 className={fr.cx("fr-col-md-7")}
                 state={data.name === "" ? "error" : "default"}
@@ -209,7 +209,7 @@ export default function AppDetailPage({
               />
             </div>
 
-            <div id="cles" className={fr.cx("fr-mb-10v")}>
+            <div id="cles" className={fr.cx("fr-mb-12v")}>
               <h2>Clés d&rsquo;API</h2>
               <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
                 <div className={fr.cx("fr-col-12")}>
@@ -251,7 +251,7 @@ export default function AppDetailPage({
               />
             </div>
 
-            <div id="alg-id-token" className={fr.cx("fr-mb-10v")}>
+            <div id="alg-id-token" className={fr.cx("fr-mb-12v")}>
               <h1 id="algs">Algorithmes</h1>
               <h2>Algorithme de signature ID Token</h2>
               <p>
@@ -272,7 +272,7 @@ export default function AppDetailPage({
                 ))}
               </Select>
             </div>
-            <div id="alg-user-info" className={fr.cx("fr-mb-10v")}>
+            <div id="alg-user-info" className={fr.cx("fr-mb-12v")}>
               <h2>Algorithme de signature user-info</h2>
               <p>
                 L&rsquo;algorithme de signature est utilisé pour signer les informations
@@ -297,7 +297,10 @@ export default function AppDetailPage({
               </Select>
             </div>
 
-            <div id="collaborators" className={fr.cx("fr-mb-10v")}>
+            <Badge severity="new" small>
+              Nouvelle fonctionnalité
+            </Badge>
+            <div id="collaborators" className={fr.cx("fr-mb-12v")}>
               <EditableList
                 items={data.collaborators}
                 onUpdate={(collaborators) => handleUpdate({ collaborators })}
@@ -312,7 +315,7 @@ export default function AppDetailPage({
               />
             </div>
 
-            <div id="production" className={fr.cx("fr-mb-10v")}>
+            <div id="production" className={fr.cx("fr-mb-12v")}>
               <h2>Passage en production</h2>
               <p>Cette application est encore en test.</p>
               <p>


### PR DESCRIPTION
**Problem**
Users of the Partner Portal need advance notice of upcoming changes that may affect access to their applications.

**Proposal**
Add a "New" badge and an announcement banner to inform users about the upcoming ProConnect migration.

<img width="772" height="246" alt="Capture d’écran 2026-07-16 à 14 45 59" src="https://github.com/user-attachments/assets/956c4a5c-a769-4397-abd1-38aeaad9b54f" />
<img width="1440" height="265" alt="Capture d’écran 2026-07-16 à 14 46 25" src="https://github.com/user-attachments/assets/5e45b3f3-00d6-49f8-8298-133e59927605" />
