### PR TITLE
🩹 Fix conflicting nodemailer peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,9 @@
     "typescript": "5.7.3",
     "unist-util-visit": "^5.0.0"
   },
+  "overrides": {
+    "nodemailer": "^9.0.1"
+  },
   "optionalDependencies": {
     "@swc/core-linux-x64-gnu": "^1.10.12"
   },


### PR DESCRIPTION
**Problem**

There is a version incompatibility between nodemailer v7, required as an optional peer dependency by `next-auth`, and nodemailer v9, which is used by the application code.

**Proposal**

Force the peer dependency to v9, as v7 is vulnerable.

There are few changes in the library usage between v7 and v9, so this change is considered safe.