### PR TITLE
docs: signaler que les liens Grist nécessitent une connexion

### DIFF
--- a/src/pages/docs/fournisseur-identite/2026_03_conformite_mfa.md
+++ b/src/pages/docs/fournisseur-identite/2026_03_conformite_mfa.md
@@ -4,7 +4,7 @@ La [Feuille de Route de Sécurité Numérique 2026-2027 de l'ANSSI](https://cybe
 
 ProConnect et ses Fournisseurs d'Identité sont concernés par cette obligation.
 
-ProConnect a récemment changé les niveaux de confiance renvoyés aux Fournisseurs d'Identité. Nous demandons à nos Fournisseurs d'Identité de verifier leur conformité MFA et de nous prévenir par mail à support.partenaires@mail.proconnect.gouv.fr. La liste des Fournisseurs d'Identité compatibles est disponibles ici : https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/13
+ProConnect a récemment changé les niveaux de confiance renvoyés aux Fournisseurs d'Identité. Nous demandons à nos Fournisseurs d'Identité de verifier leur conformité MFA et de nous prévenir par mail à support.partenaires@mail.proconnect.gouv.fr. La liste des Fournisseurs d'Identité compatibles est disponible ici : https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/13 (⚠️ accessible uniquement en se connectant)
 
 Afin de vérifier que votre Fournisseur d'Identité est conforme avec cette nouvelle norme, voici la procédure.
 

--- a/src/pages/docs/fournisseur-service/connaitre-le-fi-utilise.md
+++ b/src/pages/docs/fournisseur-service/connaitre-le-fi-utilise.md
@@ -2,7 +2,7 @@
 
 Le Fournisseur de service peut demander le scope `idp_id`, qui est systématiquement envoyé par ProConnect. Le Fournisseur de Service peut ainsi décider de quels Fournisseurs d'Identité sont autorisés pour son application.
 
-La table de correspondance entre l'ID du Fournisseur d'Identité (colonne UID) et le nom du Fournisseur d'Identité (colonne Titre) est présente [ici](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS).
+La table de correspondance entre l'ID du Fournisseur d'Identité (colonne UID) et le nom du Fournisseur d'Identité (colonne Titre) est présente [ici](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS) (⚠️ accessible uniquement en se connectant).
 
 Si lorsque vous faîtes cet appel, vous recevez l'erreur "requested scope is not allowed", c'est que le scope idp_id n'a pas été autorisé par votre FS. Vous pouvez nous écrire pour nous le demander, nous l'ajouterons automatiquement.
 

--- a/src/pages/docs/fournisseur-service/identifiants-fi-test.md
+++ b/src/pages/docs/fournisseur-service/identifiants-fi-test.md
@@ -4,7 +4,7 @@ Lorsque vous implémentez la connexion OIDC via ProConnect sur votre Fournisseur
 
 ## 📋 Liste des fournisseurs d'identité en intégration
 
-[Voici la liste des Fournisseurs d'Identité](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/18) sur notre plateforme d'intégration. Si vous avez accès à des comptes de test, vous pouvez les utiliser.
+[Voici la liste des Fournisseurs d'Identité](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/18) (⚠️ accessible uniquement en se connectant) sur notre plateforme d'intégration. Si vous avez accès à des comptes de test, vous pouvez les utiliser.
 
 ## 🔐 Fournisseur d'Identité de test
 

--- a/src/pages/docs/fournisseur-service/redirect-uri-mismatch.md
+++ b/src/pages/docs/fournisseur-service/redirect-uri-mismatch.md
@@ -18,7 +18,7 @@ De même, vos `redirect_uri` d'intégration et de production sont gérées indé
 
 ### 2.3. Mon application est-elle configurée pour Internet ? Pour la production ?
 
-Pour savoir pour quel serveur le `client_id` est configuré, allez sur [la liste complète des Fournisseurs de Service ProConnect](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/14), faites une recherche (`ctrl` + `F`) avec votre `client_id` : vous trouverez où est configurée votre application. Vous aurez aussi la liste complète des `redirect_uris` renseignées.
+Pour savoir pour quel serveur le `client_id` est configuré, allez sur [la liste complète des Fournisseurs de Service ProConnect](https://grist.numerique.gouv.fr/o/proconnect/gNkPzdjPZnv8/ProConnect-Configuration-des-FI-et-FS/p/14) (⚠️ accessible uniquement en se connectant), faites une recherche (`ctrl` + `F`) avec votre `client_id` : vous trouverez où est configurée votre application. Vous aurez aussi la liste complète des `redirect_uris` renseignées.
 
 ## 3. Comment identifier ce qui ne va pas
 


### PR DESCRIPTION
## Summary
- Ajoute un avertissement (⚠️ accessible uniquement en se connectant) sur les liens vers les tableaux Grist dans 4 pages de doc, pour éviter la confusion des lecteurs non connectés.