### PR TITLE
💬 fix: clarify ProConnect migration announcement

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -89,7 +89,7 @@ function App({ Component, pageProps: { session, ...pageProps }, router }: AppPro
           id="proconnect-will-replace-magic-link-notice"
           title="La connexion à votre Espace Partenaires se renforce."
           severity="info"
-          description="ProConnect remplacera bientôt la connexion par lien de connexion. Assurez-vous que vos applications restent accessibles en utilisant la nouvelle fonctionnalité d’ajout de personnes collaboratrices."
+          description="Les liens de connexion seront prochainement remplacés par la connexion via le bouton ProConnect. Pour garantir l’accès à vos applications, ajoutez dès maintenant les personnes concernées à vos espaces via la nouvelle fonctionnalité d’ajout de personnes collaboratrices."
         />
         <Layout>
           <Component {...pageProps} />


### PR DESCRIPTION
**Problem**
The announcement describing the transition to the new ProConnect authentication flow was unclear and could lead to user confusion.

**Proposal**
Revise the announcement text to make the upcoming ProConnect migration clearer and easier to understand.