### PR TITLE
🐛 fix(ci): save node_modules cache before pruning dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,15 @@ jobs:
           NEXT_PUBLIC_PROCONNECT_POST_LOGOUT_URI: "http://localhost:3000/api/proconnect/logout-callback"
           NEXT_PUBLIC_PROCONNECT_END_SESSION_URL: "https://fca.integ01.dev-agentconnect.fr/api/v2/session/end"
 
-      - name: 🔥 Prune dev dependencies
-        run: npm prune --omit=dev
-
       - name: 💾 Save app dependencies cache
         if: steps.cache-deps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
         with:
           path: node_modules
           key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+
+      - name: 🔥 Prune dev dependencies
+        run: npm prune --omit=dev
 
       - name: 📤 Upload build artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- The `build` job pruned devDependencies (`npm prune --omit=dev`) *before* saving the `node_modules` cache. Once that cache was rebuilt from a miss, it permanently poisoned the shared cache with a prod-only `node_modules`.
- The `lint` and `test` jobs restore that same cache key but need devDependencies (e.g. `prisma`) to run `npm run predev`, so they failed with `sh: 1: prisma: not found` any time the cache was rebuilt from scratch.
- Fix: save the cache right after the build, then prune. The prune still runs (still validates the Scalingo `npm prune` deploy path from #407), it just no longer pollutes the shared cache — nothing after it depends on `node_modules` (the artifact upload only grabs `.next/standalone/`, `.next/static/`, `packages/*/dist/`, `public/`).

## Test plan
- [ ] Confirm `lint` and `test` jobs pass on a cold cache (e.g. by bumping a dependency or manually evicting the `node-cache-*` entry)
- [ ] Confirm the `build` job's artifact still builds correctly
