### PR TITLE
✨ feat: hide Magic Link login and document application recovery

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -40,7 +40,7 @@ services:
       - /data/configdb
 
   api-partenaires:
-    image: ghcr.io/proconnect-gouv/api-partenaires:sha-56cce71 # latest
+    image: ghcr.io/proconnect-gouv/api-partenaires:sha-d71957a # latest
     depends_on:
       mongo:
         condition: service_healthy

--- a/e2e/uuv/features/login.feature
+++ b/e2e/uuv/features/login.feature
@@ -2,8 +2,7 @@
 Fonctionnalité: Connexion
 
   Scénario: Connexion avec un utilisateur via un lien de connexion envoyé par email puis via ProConnect
-    Étant donné que je visite l'Url "/"
-    Quand je clique sur le lien nommé "Se connecter"
+    Étant donné que je visite l'Url "/magic-link-login"
     Alors je dois voir un titre nommé "Connexion" avec le niveau 1
     Et je clique sur "Email professionnel"
     Quand j'entre la valeur "user@test.proconnect.gouv.fr"
@@ -52,8 +51,7 @@ Fonctionnalité: Connexion
     Quand je clique sur le bouton nommé "Déconnecter ursula@test.proconnect.gouv.fr"
     Alors je dois voir un titre nommé "Rejoignez les partenaires de ProConnect !" avec le niveau 1
 
-    Et je clique sur le lien nommé "Vos applications"
-
+    Et que je visite l'Url "/magic-link-login"
     Et je clique sur "Email professionnel"
 
     Quand j'entre la valeur "ursula@test.proconnect.gouv.fr"

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,3 +1,4 @@
+import { ClosableNotice } from "@/components/ClosableNotice";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import { Button } from "@codegouvfr/react-dsfr/Button";
@@ -78,6 +79,19 @@ export default function AppsIndex({
 
   return (
     <>
+      <ClosableNotice
+        id="cannot-find-your-apps-notice"
+        title="Vous ne retrouvez pas vos applications ?"
+        severity="warning"
+        link={{
+          text: "Documentation",
+          linkProps: {
+            href: "/docs/fournisseur-service/retrouver_apps_espace_partenaires",
+          },
+        }}
+        description="Les applications créées avec l'ancien système de connexion peuvent ne plus être accessibles. Pour les récupérer, veuillez suivre la documentation."
+      />
+
       <section
         className={fr.cx("fr-py-3w")}
         style={{

--- a/src/pages/docs/fournisseur-service/retrouver_apps_espace_partenaires.md
+++ b/src/pages/docs/fournisseur-service/retrouver_apps_espace_partenaires.md
@@ -1,0 +1,16 @@
+# Connexion à l’Espace Partenaires via ProConnect
+
+La connexion à l’Espace Partenaires se fait désormais via **ProConnect**.
+
+## Si l'e-mail de rattachement de votre application n’est pas lié à un compte ProConnect
+
+Si l’adresse e-mail utilisée pour la connexion à l’Espace Partenaires n’est pas liée à un compte ProConnect (par exemple dans le cas d'une adresse e-mail d’équipe), alors il faut :
+
+1. Se connecter avec cette adresse e-mail via ce lien : http://partenaires.proconnect.gouv.fr/magic-link-login
+2. Ajouter les adresses e-mail individuelles des membres de l’équipe via la fonctionnalité d'ajout de personnes collaboratrices, au sein de la page d'édition d'une application
+
+## Fin de l’ancien mode de connexion
+
+L’ancien mode de connexion sera complètement supprimé le **14 septembre**.
+
+Passé ce délai, si vos applications sont encore liées uniquement à l'ancien compte, elles ne seront plus accessibles. Il faudra alors **recréer une application d’intégration** en vous connectant avec votre compte ProConnect.

--- a/src/pages/docs/fournisseur-service/table_matieres.md
+++ b/src/pages/docs/fournisseur-service/table_matieres.md
@@ -88,9 +88,10 @@ Nous vous recommandons de lire [notre page généraliste sur l'implémentation t
 
 → _Trouver de l'aide en cas de problème ou de question_
 
-| Page                                                        | Question                                                                                      |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [Messages d'erreur](./troubleshooting-fs.md)                | J'ai un message d'erreur, comment le déchiffrer ?                                             |
-| [Erreur Y030031 — redirect_uri](./redirect-uri-mismatch.md) | J'ai une erreur Y030031 : ma redirect_uri n'est pas reconnue, comment résoudre le problème ?  |
-| [Service partenaires](./aide_support.md)                    | J'aimerais contacter le service partenaires de ProConnect pour de l'aide ou pour une question |
-| [Glossaire](./../ressources/glossaire.md)                   | Quel est le glossaire de tous ces termes techniques ?                                         |
+| Page                                                                                               | Question                                                                                             |
+| -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Messages d'erreur](./troubleshooting-fs.md)                                                       | J'ai un message d'erreur, comment le déchiffrer ?                                                    |
+| [Erreur Y030031 — redirect_uri](./redirect-uri-mismatch.md)                                        | J'ai une erreur Y030031 : ma redirect_uri n'est pas reconnue, comment résoudre le problème ?         |
+| [Service partenaires](./aide_support.md)                                                           | J'aimerais contacter le service partenaires de ProConnect pour de l'aide ou pour une question        |
+| [Changement de mode de connexion sur l'Espace Partenaires](./retrouver_apps_espace_partenaires.md) | Je ne retrouve plus mes apps suite au passage à ProConnect sur l'Espace Partenaires, comment faire ? |
+| [Glossaire](./../ressources/glossaire.md)                                                          | Quel est le glossaire de tous ces termes techniques ?                                                |

--- a/src/pages/magic-link-login.tsx
+++ b/src/pages/magic-link-login.tsx
@@ -1,6 +1,7 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Alert } from "@codegouvfr/react-dsfr/Alert";
-import { ProConnectButton } from "@codegouvfr/react-dsfr/ProConnectButton";
+import Button from "@codegouvfr/react-dsfr/Button";
+import Input from "@codegouvfr/react-dsfr/Input";
 import { GetServerSideProps, NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
 import { signIn } from "next-auth/react";
@@ -29,21 +30,27 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: {} };
 };
 
-export default function Login() {
+export default function MagicLinkLogin() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
   const [authenticationError, setAuthenticationError] = useState("");
   const router = useRouter();
   const oidcCallbackError = router.query.error as string | undefined;
 
-  const handleProConnectLogin = async (e: React.FormEvent<HTMLButtonElement>) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setIsLoading(true);
     setAuthenticationError("");
 
     try {
-      await signIn("proconnect", {
+      await signIn("email", {
+        email,
         callbackUrl: "/apps",
       });
     } catch {
       setAuthenticationError("Une erreur est survenue. Veuillez réessayer.");
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -69,9 +76,30 @@ export default function Login() {
                 />
               )}
 
-              <div style={{ textAlign: "center" }}>
-                <ProConnectButton onClick={handleProConnectLogin} />
-              </div>
+              <form onSubmit={handleSubmit}>
+                <Input
+                  label="Email professionnel"
+                  nativeInputProps={{
+                    type: "email",
+                    value: email,
+                    onChange: (e) => setEmail(e.target.value.trim()),
+                    required: true,
+                    autoComplete: "email",
+                    disabled: isLoading,
+                  }}
+                />
+                <div className={fr.cx("fr-mt-2w")}>
+                  <Button type="submit" disabled={isLoading || !email}>
+                    {isLoading ? "Envoi en cours..." : "Recevoir un lien de connexion"}
+                  </Button>
+                </div>
+              </form>
+
+              <p className={fr.cx("fr-mt-3w", "fr-mb-0", "fr-text--sm")}>
+                Un lien de connexion sécurisé vous sera envoyé par email.
+                <br />
+                Ce lien est valable 24 heures.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
**Problem**
The application still exposes two authentication methods: Magic Link and ProConnect, which can be confusing during the migration.

**Proposal**
Hide the Magic Link authentication flow and add documentation explaining how users can recover access to their applications.