### PR TITLE
📝 docs: update Partner Portal link to HTTPS

### DIFF
--- a/src/pages/docs/fournisseur-service/retrouver_apps_espace_partenaires.md
+++ b/src/pages/docs/fournisseur-service/retrouver_apps_espace_partenaires.md
@@ -6,7 +6,7 @@ La connexion à l’Espace Partenaires se fait désormais via **ProConnect**.
 
 Si l’adresse e-mail utilisée pour la connexion à l’Espace Partenaires n’est pas liée à un compte ProConnect (par exemple dans le cas d'une adresse e-mail d’équipe), alors il faut :
 
-1. Se connecter avec cette adresse e-mail via ce lien : http://partenaires.proconnect.gouv.fr/magic-link-login
+1. Se connecter avec cette adresse e-mail via ce lien : https://partenaires.proconnect.gouv.fr/magic-link-login
 2. Ajouter les adresses e-mail individuelles des membres de l’équipe via la fonctionnalité d'ajout de personnes collaboratrices, au sein de la page d'édition d'une application
 
 ## Fin de l’ancien mode de connexion


### PR DESCRIPTION
**Problem**
The documentation links to the Partner Portal using HTTP instead of HTTPS.

**Proposal**
Update the link to use HTTPS.