### PR TITLE
♻️ refactor: standardize scripts commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: npm run predev
 
       - name: ⛑️ Lint
-        run: npm run test:lint
+        run: npm run lint
 
   test:
     name: 💪 Test
@@ -271,7 +271,7 @@ jobs:
 
       - name: 🎬 Run Playwright tests
         working-directory: ./e2e
-        run: npm run test:video
+        run: npm run test:e2e:video
         env:
           PROCONNECT_CLIENT_ID: ${{ secrets.PROCONNECT_CLIENT_ID }}
           PROCONNECT_CLIENT_SECRET: ${{ secrets.PROCONNECT_CLIENT_SECRET }}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,9 +22,7 @@ npm install
 
 ### Debug & Development
 
-- **`npm run test:debug`** - Run tests with browser visible and slow motion for debugging
-- **`npm run test:screenshot`** - Run tests and capture screenshots only on failure
-- **`npm run test:video`** - Run tests with video recording enabled
+- **`npm run test:e2e:video`** - Run tests with video recording enabled
 
 ## Project Structure
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "test": "uuv run",
-    "studio": "uuv open",
-    "test:video": "PW_VIDEO=1 uuv run"
+    "test:e2e": "uuv run",
+    "test:e2e:studio": "uuv open",
+    "test:e2e:video": "PW_VIDEO=1 uuv run"
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
     "predev": "npm run prisma:generate && node -r @swc-node/register scripts/generate-search-index.ts && npm run build:packages && npm run only-include-used-icons",
     "dev": "next dev",
     "postinstall": "rm -f node_modules/@kitajs/html/*.d.ts",
-    "lint": "prettier --write '**/*.{feature,ts,tsx,css,md,mdx,mjs,js}' --print-width 100 && eslint --no-cache . && npm run type-check",
+    "format": "prettier --write '**/*.{feature,ts,tsx,css,md,mdx,mjs,js}' --print-width 100",
     "migrate": "prisma migrate",
     "only-include-used-icons": "node node_modules/@codegouvfr/react-dsfr/bin/only-include-used-icons.js",
     "prisma:generate": "prisma generate --schema=./prisma/db_espace.prisma && prisma generate --schema=./prisma/db_proconnect.prisma",
     "prod:prune": "find node_modules -type f -name '*.map' -delete && rm -rf .next/cache",
     "start": "node .next/standalone/server.js",
-    "test": "npm run test:lint",
+    "test": "npm run lint",
     "test:links": "start-server-and-test 'npm run dev' 3000 'linkinator 'http://localhost:3000' --recurse --skip \"^(?!http://localhost:3000)\"'",
-    "test:lint": "prettier '**/*.{feature,ts,tsx,css,md,mdx,mjs,js}' --list-different --print-width 100 && eslint --no-cache . && npm run type-check",
-    "type-check": "tsc --noEmit"
+    "lint": "prettier '**/*.{feature,ts,tsx,css,md,mdx,mjs,js}' --list-different --print-width 100 && eslint --no-cache . && npm run type:check",
+    "type:check": "tsc --noEmit"
   },
   "prettier": {
     "plugins": [


### PR DESCRIPTION
**Problem**
Script commands have legacy names and are not consistent across projects.

**Proposal**
- Remove the `low` suffix from all test commands.
- Use `test:e2e:studio` to open Cypress Studio.
- Use `test:e2e` to run E2E tests.
- Use `lint` to check linting
- Use `type:check` to check transpilation
- Use `format` to format the code with right linting and formatting